### PR TITLE
Manual: Extract function Tpetra::CrsMatrix::transferAndFillComplete() refactoring - 2025-06-04

### DIFF
--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -282,6 +282,8 @@ namespace Tpetra {
                   MultiVector<SC,LO,GO,NO> & R);
   }
 
+  namespace Details { class CommRequest; }
+
   /// \class CrsMatrix
   /// \brief Sparse matrix that presents a row-oriented interface that
   ///   lets users read or modify entries.
@@ -3539,6 +3541,23 @@ public:
                              const Teuchos::RCP<const map_type>& domainMap = Teuchos::null,
                              const Teuchos::RCP<const map_type>& rangeMap = Teuchos::null,
                              const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null) const;
+
+    /// Helpers for transferAndFillComplete()
+
+    void
+    transferAndFillComplete_getCallersParamters(
+      // Input args
+      const ::Tpetra::Details::Transfer<LocalOrdinal, GlobalOrdinal, Node>& rowTransfer,
+      const Teuchos::RCP<Teuchos::ParameterList>& params,
+      // Output args
+      bool &isMM,
+      bool &reverseMode,
+      bool &restrictComm,
+      Teuchos::RCP<Teuchos::ParameterList> &matrixparams,
+      bool &useKokkosPath,
+      std::shared_ptr< ::Tpetra::Details::CommRequest> &iallreduceRequest,
+      int &reduced_mismatch
+      ) const;
 
     /// \brief Common implementation detail of insertGlobalValues and
     ///   insertGlobalValuesFiltered.

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -3542,23 +3542,6 @@ public:
                              const Teuchos::RCP<const map_type>& rangeMap = Teuchos::null,
                              const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null) const;
 
-    /// Helpers for transferAndFillComplete()
-
-    void
-    transferAndFillComplete_getCallersParamters(
-      // Input args
-      const ::Tpetra::Details::Transfer<LocalOrdinal, GlobalOrdinal, Node>& rowTransfer,
-      const Teuchos::RCP<Teuchos::ParameterList>& params,
-      // Output args
-      bool &isMM,
-      bool &reverseMode,
-      bool &restrictComm,
-      Teuchos::RCP<Teuchos::ParameterList> &matrixparams,
-      bool &useKokkosPath,
-      std::shared_ptr< ::Tpetra::Details::CommRequest> &iallreduceRequest,
-      int &reduced_mismatch
-      ) const;
-
     /// \brief Common implementation detail of insertGlobalValues and
     ///   insertGlobalValuesFiltered.
     ///

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -7740,44 +7740,20 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     //
     // Get the caller's parameters
     //
-    bool isMM = false; // optimize for matrix-matrix ops.
-    bool reverseMode = false; // Are we in reverse mode?
-    bool restrictComm = false; // Do we need to restrict the communicator?
 
-    int mm_optimization_core_count =
-      Behavior::TAFC_OptimizationCoreCount();
-    RCP<ParameterList> matrixparams; // parameters for the destination matrix
-    bool overrideAllreduce = false;
+    bool isMM = false;
+    bool reverseMode = false;
+    bool restrictComm = false;
+    RCP<ParameterList> matrixparams;
     bool useKokkosPath = false;
-    if (! params.is_null ()) {
-      matrixparams = sublist (params, "CrsMatrix");
-      reverseMode = params->get ("Reverse Mode", reverseMode);
-      useKokkosPath = params->get ("TAFC: use kokkos path", useKokkosPath);
-      restrictComm = params->get ("Restrict Communicator", restrictComm);
-      auto & slist = params->sublist("matrixmatrix: kernel params",false);
-      isMM = slist.get("isMatrixMatrix_TransferAndFillComplete",false);
-      mm_optimization_core_count = slist.get("MM_TAFC_OptimizationCoreCount",mm_optimization_core_count);
+    std::shared_ptr< ::Tpetra::Details::CommRequest> iallreduceRequest;
+    int reduced_mismatch = 0;
 
-      overrideAllreduce = slist.get("MM_TAFC_OverrideAllreduceCheck",false);
-      if(getComm()->getSize() < mm_optimization_core_count && isMM)   isMM = false;
-      if(reverseMode) isMM = false;
-    }
-
-   // Only used in the sparse matrix-matrix multiply (isMM) case.
-   std::shared_ptr< ::Tpetra::Details::CommRequest> iallreduceRequest;
-   int mismatch = 0;
-   int reduced_mismatch = 0;
-   if (isMM && !overrideAllreduce) {
-
-     // Test for pathological matrix transfer
-     const bool source_vals = ! getGraph ()->getImporter ().is_null();
-     const bool target_vals = ! (rowTransfer.getExportLIDs ().size() == 0 ||
-                                 rowTransfer.getRemoteLIDs ().size() == 0);
-     mismatch = (source_vals != target_vals) ? 1 : 0;
-     iallreduceRequest =
-       ::Tpetra::Details::iallreduce (mismatch, reduced_mismatch,
-                                      Teuchos::REDUCE_MAX, * (getComm ()));
-   }
+    transferAndFillComplete_getCallersParamters(
+      rowTransfer, params,
+      isMM, reverseMode, restrictComm, matrixparams, useKokkosPath, iallreduceRequest,
+      reduced_mismatch
+      );
 
 #ifdef HAVE_TPETRA_MMM_TIMINGS
     using Teuchos::TimeMonitor;
@@ -9135,6 +9111,65 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
       std::cerr << os.str ();
     }
   } //transferAndFillComplete
+
+
+  template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+  void
+  CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
+  transferAndFillComplete_getCallersParamters(
+    // Input args
+    const ::Tpetra::Details::Transfer<LocalOrdinal, GlobalOrdinal, Node>& rowTransfer,
+    const Teuchos::RCP<Teuchos::ParameterList>& params,
+    // Output args
+    bool &isMM,
+    bool &reverseMode,
+    bool &restrictComm,
+    Teuchos::RCP<Teuchos::ParameterList> &matrixparams,
+    bool &useKokkosPath,
+    std::shared_ptr< ::Tpetra::Details::CommRequest> &iallreduceRequest,
+    int &reduced_mismatch
+    ) const
+  {
+    using Details::Behavior;
+
+    isMM = false; // optimize for matrix-matrix ops.
+    reverseMode = false; // Are we in reverse mode?
+    restrictComm = false; // Do we need to restrict the communicator?
+
+    int mm_optimization_core_count =
+      Behavior::TAFC_OptimizationCoreCount();
+    bool overrideAllreduce = false;
+    useKokkosPath = false;
+    if (! params.is_null ()) {
+      matrixparams = sublist (params, "CrsMatrix");
+      reverseMode = params->get ("Reverse Mode", reverseMode);
+      useKokkosPath = params->get ("TAFC: use kokkos path", useKokkosPath);
+      restrictComm = params->get ("Restrict Communicator", restrictComm);
+      auto & slist = params->sublist("matrixmatrix: kernel params",false);
+      isMM = slist.get("isMatrixMatrix_TransferAndFillComplete",false);
+      mm_optimization_core_count = slist.get("MM_TAFC_OptimizationCoreCount",mm_optimization_core_count);
+
+      overrideAllreduce = slist.get("MM_TAFC_OverrideAllreduceCheck",false);
+      if(getComm()->getSize() < mm_optimization_core_count && isMM)   isMM = false;
+      if(reverseMode) isMM = false;
+    }
+
+   // Only used in the sparse matrix-matrix multiply (isMM) case.
+   int mismatch = 0;
+   reduced_mismatch = 0;
+   if (isMM && !overrideAllreduce) {
+
+     // Test for pathological matrix transfer
+     const bool source_vals = ! getGraph ()->getImporter ().is_null();
+     const bool target_vals = ! (rowTransfer.getExportLIDs ().size() == 0 ||
+                                 rowTransfer.getRemoteLIDs ().size() == 0);
+     mismatch = (source_vals != target_vals) ? 1 : 0;
+     iallreduceRequest =
+       ::Tpetra::Details::iallreduce (mismatch, reduced_mismatch,
+                                      Teuchos::REDUCE_MAX, * (getComm ()));
+   }
+
+  }
 
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>


### PR DESCRIPTION
Manual refactoring of extract function from Tpetra::CrsMstrix::transferAndFillComplete() refactoring.  I did the basic extract function in first commit then follow-up refactoring to make free function that could be run in a unit test harness by itself.

See commit messages for details.
