### PR TITLE
Better OpenHands attempt to Extract function with devstral-small-2505 2025-08-28

### DIFF
--- a/packages/teuchos/core/src/Teuchos_CommandLineProcessor.cpp
+++ b/packages/teuchos/core/src/Teuchos_CommandLineProcessor.cpp
@@ -252,152 +252,28 @@ CommandLineProcessor::parse(
   ) const
 {
   add_extra_output_setup_options();
-  std::string        opt_name;
-  std::string        opt_val_str;
-  const std::string  echo_cl_opt = "echo-command-line";
-  const std::string  help_opt = "help";
-  const std::string  pause_opt = "pause-for-debugging";
-  int procRank = GlobalMPISession::getRank();
 
-  // check for help options before any others as we modify
-  // the values afterwards
-  for( int i = 1; i < argc; ++i ) {
-    bool gov_return = get_opt_val( argv[i], &opt_name, &opt_val_str );
-    if( gov_return && opt_name == help_opt ) {
-      if(errout) printHelpMessage( argv[0], *errout );
-      return PARSE_HELP_PRINTED;
-    }
+  // Check for help option first
+  if (checkHelpOption(argc, argv, errout)) {
+    return PARSE_HELP_PRINTED;
   }
-  // check all other options
-  for( int i = 1; i < argc; ++i ) {
-    bool gov_return = get_opt_val( argv[i], &opt_name, &opt_val_str );
-    if( !gov_return ) {
-      if(procRank == 0)
-        print_bad_opt(i,argv,errout);
-      if( recogniseAllOptions() )
-        return PARSE_UNRECOGNIZED_OPTION;
-      else {
-        continue;
-      }
-    }
-    if( opt_name == echo_cl_opt ) {
-      if(errout && procRank == 0) {
-        *errout << "\nEchoing the command-line:\n\n";
-        for( int j = 0; j < argc; ++j )
-          *errout << argv[j] << " ";
-        *errout << "\n\n";
-      }
-      continue;
-    }
-    if( opt_name == pause_opt ) {
-#ifndef _WIN32
-      Array<int> pids;
-      pids.resize(GlobalMPISession::getNProc());
-      int rank_pid = getpid();
-      GlobalMPISession::allGather(rank_pid,pids());
-      if(procRank == 0)
-        for (int k=0; k<GlobalMPISession::getNProc(); k++)
-          std::cerr << "Rank " << k << " has PID " << pids[k] << std::endl;
-#endif
-      if(procRank == 0) {
-        std::cerr << "\nType 0 and press enter to continue : ";
-        int dummy_int = 0;
-        std::cin >> dummy_int;
-      }
-      GlobalMPISession::barrier();
-      continue;
-    }
-    // Lookup the option (we had better find it!)
-    options_list_t::iterator  itr = options_list_.find(opt_name);
-    if( itr == options_list_.end() ) {
-      if(procRank == 0)
-        print_bad_opt(i,argv,errout);
-      if( recogniseAllOptions() )
-        return PARSE_UNRECOGNIZED_OPTION;
-      else
-        continue;
-    }
-    // Changed access to second value of std::map to not use overloaded arrow operator,
-    // otherwise this code will not compile on Janus (HKT, 12/01/2003)
-    opt_val_val_t &opt_val_val = (*itr).second;
-    opt_val_val.was_read = true;
-    switch( opt_val_val.opt_type ) {
-      case OPT_BOOL_TRUE:
-        *(any_cast<bool*>(opt_val_val.opt_val)) = true;
-        break;
-      case OPT_BOOL_FALSE:
-        *(any_cast<bool*>(opt_val_val.opt_val)) = false;
-        break;
-      case OPT_INT:
-        *(any_cast<int*>(opt_val_val.opt_val)) = asSafe<int> (opt_val_str);
-        break;
-      case OPT_LONG_INT:
-        *(any_cast<long int*>(opt_val_val.opt_val)) = asSafe<long int> (opt_val_str);
-        break;
-      case OPT_SIZE_T:
-        *(any_cast<size_t *>(opt_val_val.opt_val)) = asSafe<size_t> (opt_val_str);
-        break;
-      case OPT_LONG_LONG_INT:
-        *(any_cast<long long int*>(opt_val_val.opt_val)) = asSafe<long long int> (opt_val_str);
-        break;
-      case OPT_DOUBLE:
-        *(any_cast<double*>(opt_val_val.opt_val)) = asSafe<double> (opt_val_str);
-        break;
-      case OPT_FLOAT:
-        *(any_cast<float*>(opt_val_val.opt_val)) = asSafe<float> (opt_val_str);
-        break;
-      case OPT_STRING:
-        *(any_cast<std::string*>(opt_val_val.opt_val)) = remove_quotes(opt_val_str);
-        break;
-      case OPT_ENUM_INT:
-        if( !set_enum_value( i, argv, opt_name, any_cast<int>(opt_val_val.opt_val),
-            remove_quotes(opt_val_str), errout ) )
-        {
-          return PARSE_UNRECOGNIZED_OPTION;
-        }
-        break;
-      default:
-        TEUCHOS_TEST_FOR_EXCEPT(true); // Local programming error only
-    }
+
+  // Process all other options
+  EParseCommandLineReturn return_code = processOptions(argc, argv, errout);
+  if (return_code != PARSE_SUCCESSFUL) {
+    return return_code;
   }
-  // Look for options that were required but were not set
-  for(
-    options_list_t::const_iterator itr = options_list_.begin();
-    itr != options_list_.end();
-    ++itr
-    )
-  {
-    const opt_val_val_t   &opt_val_val  = (*itr).second;
-    if( opt_val_val.required && !opt_val_val.was_read ) {
-      const std::string     &opt_val_name = (*itr).first;
-#define CLP_ERR_MSG \
-      "Error, the option --"<<opt_val_name<<" was required but was not set!"
-      if(errout)
-        *errout << std::endl << argv[0] << " : " << CLP_ERR_MSG << std::endl;
-      if( throwExceptions() ) {
-        TEUCHOS_TEST_FOR_EXCEPTION( true, ParseError, CLP_ERR_MSG );
-      }
-      return PARSE_ERROR;
-#undef CLP_ERR_MSG
-    }
+
+  // Check for required options
+  if (checkRequiredOptions(argv, errout)) {
+    return PARSE_ERROR;
   }
-  // Set the options of a default stream exists and if we are asked to
-  RCP<FancyOStream>
-    defaultOut = VerboseObjectBase::getDefaultOStream();
-  if (defaultOut.get() && addOutputSetupOptions_) {
-    if (output_all_front_matter_ != output_all_front_matter_default_)
-      defaultOut->setShowAllFrontMatter(output_all_front_matter_);
-    if (output_show_line_prefix_ != output_show_line_prefix_default_)
-      defaultOut->setShowLinePrefix(output_show_line_prefix_);
-    if (output_show_tab_count_ != output_show_tab_count_default_)
-      defaultOut->setShowTabCount(output_show_tab_count_);
-    if (output_show_proc_rank_ != output_show_proc_rank_default_)
-      defaultOut->setShowProcRank(output_show_proc_rank_);
-    if (output_to_root_rank_only_ != output_to_root_rank_only_default_)
-      defaultOut->setOutputToRootOnly(output_to_root_rank_only_);
-    RCPNodeTracer::setPrintRCPNodeStatisticsOnExit(print_rcpnode_statistics_on_exit_);
-  }
+
+  // Set output options if a default stream exists and if requested
+  setOutputOptions();
+
   return PARSE_SUCCESSFUL;
+}
 }
 
 
@@ -852,3 +728,254 @@ CommandLineProcessor::getRawTimeMonitorSurrogate()
 
 
 } // end namespace Teuchos
+
+// Check for help option and print help message if found
+bool CommandLineProcessor::checkHelpOption(
+  int             argc,
+  char*          argv[],
+  std::ostream   *errout
+  ) const
+{
+  std::string opt_name;
+  std::string opt_val_str;
+  const std::string help_opt = "help";
+
+  // check for help options before any others as we modify the values afterwards
+  for( int i = 1; i < argc; ++i ) {
+    bool gov_return = get_opt_val( argv[i], &opt_name, &opt_val_str );
+    if( gov_return && opt_name == help_opt ) {
+      if(errout) printHelpMessage( argv[0], *errout );
+      return true;
+    }
+  }
+  return false;
+}
+
+// Process all command line options
+CommandLineProcessor::EParseCommandLineReturn CommandLineProcessor::processOptions(
+  int             argc,
+  char*          argv[],
+  std::ostream   *errout
+  ) const
+{
+  std::string opt_name;
+  std::string opt_val_str;
+  const std::string echo_cl_opt = "echo-command-line";
+  const std::string pause_opt = "pause-for-debugging";
+  int procRank = GlobalMPISession::getRank();
+
+  // check all options
+  for( int i = 1; i < argc; ++i ) {
+    bool gov_return = get_opt_val( argv[i], &opt_name, &opt_val_str );
+    if( !gov_return ) {
+      if(procRank == 0)
+        print_bad_opt(i,argv,errout);
+      if( recogniseAllOptions() )
+        return PARSE_UNRECOGNIZED_OPTION;
+      else {
+        continue;
+      }
+    }
+
+    // Handle special options
+    if (handleSpecialOptions(i, argc, argv, opt_name, echo_cl_opt, pause_opt, errout, procRank)) {
+      continue;
+    }
+
+    // Process recognized options
+    if (!processRecognizedOption(opt_name, opt_val_str, i, argv, errout)) {
+      return PARSE_UNRECOGNIZED_OPTION;
+    }
+  }
+
+  return PARSE_SUCCESSFUL;
+}
+
+// Handle special options like echo-command-line and pause-for-debugging
+bool CommandLineProcessor::handleSpecialOptions(
+  int             i,
+  int             argc,
+  char*          argv[],
+  const std::string &opt_name,
+  const std::string &echo_cl_opt,
+  const std::string &pause_opt,
+  std::ostream   *errout,
+  int             procRank
+  ) const
+{
+  if( opt_name == echo_cl_opt ) {
+    if(errout && procRank == 0) {
+      *errout << "\nEchoing the command-line:\n\n";
+      for( int j = 0; j < argc; ++j )
+        *errout << argv[j] << " ";
+      *errout << "\n\n";
+    }
+    return true;
+  }
+
+  if( opt_name == pause_opt ) {
+    handlePauseForDebugging(procRank);
+    return true;
+  }
+
+  return false;
+}
+
+// Handle pause-for-debugging option
+void CommandLineProcessor::handlePauseForDebugging(
+  int procRank
+  ) const
+{
+#ifndef _WIN32
+  Array<int> pids;
+  pids.resize(GlobalMPISession::getNProc());
+  int rank_pid = getpid();
+  GlobalMPISession::allGather(rank_pid,pids());
+  if(procRank == 0)
+    for (int k=0; k<GlobalMPISession::getNProc(); k++)
+      std::cerr << "Rank " << k << " has PID " << pids[k] << std::endl;
+#endif
+  if(procRank == 0) {
+    std::cerr << "\nType 0 and press enter to continue : ";
+    int dummy_int = 0;
+    std::cin >> dummy_int;
+  }
+  GlobalMPISession::barrier();
+}
+
+// Process a recognized option
+bool CommandLineProcessor::processRecognizedOption(
+  const std::string &opt_name,
+  const std::string &opt_val_str,
+  int             i,
+  char*          argv[],
+  std::ostream   *errout
+  ) const
+{
+  // Lookup the option (we had better find it!)
+  options_list_t::iterator  itr = options_list_.find(opt_name);
+  if( itr == options_list_.end() ) {
+    if(GlobalMPISession::getRank() == 0)
+      print_bad_opt(i,argv,errout);
+    if( recogniseAllOptions() )
+      return false;
+    else
+      return true;
+  }
+
+  // Changed access to second value of std::map to not use overloaded arrow operator,
+  // otherwise this code will not compile on Janus (HKT, 12/01/2003)
+  opt_val_val_t &opt_val_val = (*itr).second;
+  opt_val_val.was_read = true;
+
+  return processOptionValue(opt_val_val, opt_val_str);
+}
+
+// Process the value of a recognized option
+bool CommandLineProcessor::processOptionValue(
+  opt_val_val_t &opt_val_val,
+  const std::string &opt_val_str
+  ) const
+{
+  switch( opt_val_val.opt_type ) {
+    case OPT_BOOL_TRUE:
+      *(any_cast<bool*>(opt_val_val.opt_val)) = true;
+      break;
+    case OPT_BOOL_FALSE:
+      *(any_cast<bool*>(opt_val_val.opt_val)) = false;
+      break;
+    case OPT_INT:
+      *(any_cast<int*>(opt_val_val.opt_val)) = asSafe<int> (opt_val_str);
+      break;
+    case OPT_LONG_INT:
+      *(any_cast<long int*>(opt_val_val.opt_val)) = asSafe<long int> (opt_val_str);
+      break;
+    case OPT_SIZE_T:
+      *(any_cast<size_t *>(opt_val_val.opt_val)) = asSafe<size_t> (opt_val_str);
+      break;
+    case OPT_LONG_LONG_INT:
+      *(any_cast<long long int*>(opt_val_val.opt_val)) = asSafe<long long int> (opt_val_str);
+      break;
+    case OPT_DOUBLE:
+      *(any_cast<double*>(opt_val_val.opt_val)) = asSafe<double> (opt_val_str);
+      break;
+    case OPT_FLOAT:
+      *(any_cast<float*>(opt_val_val.opt_val)) = asSafe<float> (opt_val_str);
+      break;
+    case OPT_STRING:
+      *(any_cast<std::string*>(opt_val_val.opt_val)) = remove_quotes(opt_val_str);
+      break;
+    case OPT_ENUM_INT: {
+      std::string enum_str_val = remove_quotes(opt_val_str);
+      // We need to find the option name from the options_list_
+      std::string opt_name;
+      for (options_list_t::const_iterator itr = options_list_.begin();
+          itr != options_list_.end();
+          ++itr) {
+        if (&(*itr).second == &opt_val_val) {
+          opt_name = (*itr).first;
+          break;
+        }
+      }
+      if( !set_enum_value( -1, NULL, opt_name, any_cast<int>(opt_val_val.opt_val),
+          enum_str_val, NULL ) )
+      {
+        return false;
+      }
+      break;
+    }
+    default:
+      TEUCHOS_TEST_FOR_EXCEPT(true); // Local programming error only
+  }
+
+  return true;
+}
+
+// Check for required options that were not set
+bool CommandLineProcessor::checkRequiredOptions(
+  char*          argv[],
+  std::ostream   *errout
+  ) const
+{
+  for(
+    options_list_t::const_iterator itr = options_list_.begin();
+    itr != options_list_.end();
+    ++itr
+    )
+  {
+    const opt_val_val_t   &opt_val_val  = (*itr).second;
+    if( opt_val_val.required && !opt_val_val.was_read ) {
+      const std::string     &opt_val_name = (*itr).first;
+#define CLP_ERR_MSG \
+      "Error, the option --"<<opt_val_name<<" was required but was not set!"
+      if(errout)
+        *errout << std::endl << argv[0] << " : " << CLP_ERR_MSG << std::endl;
+      if( throwExceptions() ) {
+        TEUCHOS_TEST_FOR_EXCEPTION( true, ParseError, CLP_ERR_MSG );
+      }
+      return true;
+#undef CLP_ERR_MSG
+    }
+  }
+  return false;
+}
+
+// Set output options if a default stream exists and if requested
+void CommandLineProcessor::setOutputOptions() const
+{
+  RCP<FancyOStream>
+    defaultOut = VerboseObjectBase::getDefaultOStream();
+  if (defaultOut.get() && addOutputSetupOptions_) {
+    if (output_all_front_matter_ != output_all_front_matter_default_)
+      defaultOut->setShowAllFrontMatter(output_all_front_matter_);
+    if (output_show_line_prefix_ != output_show_line_prefix_default_)
+      defaultOut->setShowLinePrefix(output_show_line_prefix_);
+    if (output_show_tab_count_ != output_show_tab_count_default_)
+      defaultOut->setShowTabCount(output_show_tab_count_);
+    if (output_show_proc_rank_ != output_show_proc_rank_default_)
+      defaultOut->setShowProcRank(output_show_proc_rank_);
+    if (output_to_root_rank_only_ != output_to_root_rank_only_default_)
+      defaultOut->setOutputToRootOnly(output_to_root_rank_only_);
+    RCPNodeTracer::setPrintRCPNodeStatisticsOnExit(print_rcpnode_statistics_on_exit_);
+  }
+}

--- a/packages/teuchos/core/src/Teuchos_CommandLineProcessor.hpp
+++ b/packages/teuchos/core/src/Teuchos_CommandLineProcessor.hpp
@@ -378,6 +378,112 @@ public:
     ,std::ostream   *errout = &std::cerr
     ) const;
 
+  /** \brief Check for help option and print help message if found.
+   *
+   * \param  argc    [in] number of entries in argv[]
+   * \param  argv    [in] array (length argc) of command line arguments.
+   * \param  errout  [out] If <tt>!=NULL</tt> then help messages are sent here.
+   *
+   * \return true if help was printed, false otherwise.
+   */
+  bool checkHelpOption(
+    int             argc,
+    char*          argv[],
+    std::ostream   *errout = &std::cerr
+    ) const;
+
+  /** \brief Process all command line options.
+   *
+   * \param  argc    [in] number of entries in argv[]
+   * \param  argv    [in/out] array (length argc) of command line arguments.
+   * \param  errout  [out] If <tt>!=NULL</tt> then error messages are sent here.
+   *
+   * \return One of the EParseCommandLineReturn enum values.
+   */
+  EParseCommandLineReturn processOptions(
+    int             argc,
+    char*          argv[],
+    std::ostream   *errout = &std::cerr
+    ) const;
+
+  /** \brief Handle special options like echo-command-line and pause-for-debugging.
+   *
+   * \param  i            [in] current argument index
+   * \param  argc         [in] number of entries in argv[]
+   * \param  argv         [in] array (length argc) of command line arguments.
+   * \param  opt_name      [in] name of the option
+   * \param  echo_cl_opt   [in] echo command-line option name
+   * \param  pause_opt     [in] pause-for-debugging option name
+   * \param  errout       [out] If <tt>!=NULL</tt> then output is sent here.
+   * \param  procRank     [in] MPI process rank
+   *
+   * \return true if a special option was handled, false otherwise.
+   */
+  bool handleSpecialOptions(
+    int             i,
+    int             argc,
+    char*          argv[],
+    const std::string &opt_name,
+    const std::string &echo_cl_opt,
+    const std::string &pause_opt,
+    std::ostream   *errout,
+    int             procRank
+    ) const;
+
+  /** \brief Handle pause-for-debugging option.
+   *
+   * \param  procRank  [in] MPI process rank
+   */
+  void handlePauseForDebugging(
+    int procRank
+    ) const;
+
+  /** \brief Process a recognized option.
+   *
+   * \param  opt_name     [in] name of the option
+   * \param  opt_val_str  [in] value of the option
+   * \param  i           [in] current argument index
+   * \param  argv        [in] array of command line arguments.
+   * \param  errout      [out] If <tt>!=NULL</tt> then error messages are sent here.
+   *
+   * \return true if the option was processed successfully, false otherwise.
+   */
+  bool processRecognizedOption(
+    const std::string &opt_name,
+    const std::string &opt_val_str,
+    int             i,
+    char*          argv[],
+    std::ostream   *errout
+    ) const;
+
+  /** \brief Process the value of a recognized option.
+   *
+   * \param  opt_val_val  [in/out] option value structure
+   * \param  opt_val_str  [in] value of the option as a string
+   *
+   * \return true if the option value was processed successfully, false otherwise.
+   */
+  bool processOptionValue(
+    opt_val_val_t &opt_val_val,
+    const std::string &opt_val_str
+    ) const;
+
+  /** \brief Check for required options that were not set.
+   *
+   * \param  argv    [in] array of command line arguments.
+   * \param  errout  [out] If <tt>!=NULL</tt> then error messages are sent here.
+   *
+   * \return true if a required option was not set, false otherwise.
+   */
+  bool checkRequiredOptions(
+    char*          argv[],
+    std::ostream   *errout = &std::cerr
+    ) const;
+
+  /** \brief Set output options if a default stream exists and if requested.
+   */
+  void setOutputOptions() const;
+
   //@}
 
   //! @name Miscellaneous


### PR DESCRIPTION
This was produced by OpenHands using the openrounter.ai model openrouter/mistralai/devstral-small-2505:free using the prompt:

----

Perform the Extract Function refactoring on the function Teuchos::CommandLineProcessor::parse() that is declared and defined in the files packages/teuchos/core/src/Teuchos_CommandLineProcessor.hpp and packages/teuchos/core/src/Teuchos_CommandLineProcessor.cpp. Extract out functions to make the code simpler and easier to maintain. Update the parent function to call the new functions.

----

There was no build or test feedback and the agent timeed out at 500 iterations.  (Not sure what an "Iteration" is in this context.)

This was a free model so this was a cheap experiment :-)  Looking on operounter.ai/activity, it looks like this used less than 2.3M tokens.
