### PR TITLE
Extract function refactoring of Teuhos::CommandLineProessor::parse() with Openhands gpt-5 2025-08-29

### DIFF
--- a/packages/teuchos/core/src/Teuchos_CommandLineProcessor.cpp
+++ b/packages/teuchos/core/src/Teuchos_CommandLineProcessor.cpp
@@ -252,54 +252,67 @@ CommandLineProcessor::parse(
   ) const
 {
   add_extra_output_setup_options();
-  std::string        opt_name;
-  std::string        opt_val_str;
-  const std::string  echo_cl_opt = "echo-command-line";
-  const std::string  help_opt = "help";
-  const std::string  pause_opt = "pause-for-debugging";
-  int procRank = GlobalMPISession::getRank();
+  EParseCommandLineReturn r = checkForHelpOption(argc, argv, errout);
+  if (r != PARSE_SUCCESSFUL) return r;
+  r = processArguments(argc, argv, errout);
+  if (r != PARSE_SUCCESSFUL) return r;
+  return finalizeOptions(argv[0], errout);
+}
 
-  // check for help options before any others as we modify
-  // the values afterwards
-  for( int i = 1; i < argc; ++i ) {
-    bool gov_return = get_opt_val( argv[i], &opt_name, &opt_val_str );
-    if( gov_return && opt_name == help_opt ) {
-      if(errout) printHelpMessage( argv[0], *errout );
+CommandLineProcessor::EParseCommandLineReturn
+CommandLineProcessor::checkForHelpOption(int argc, char* argv[], std::ostream* errout) const
+{
+  std::string opt_name;
+  std::string opt_val_str;
+  const std::string help_opt = "help";
+  for (int i = 1; i < argc; ++i) {
+    bool gov_return = get_opt_val(argv[i], &opt_name, &opt_val_str);
+    if (gov_return && opt_name == help_opt) {
+      if (errout) printHelpMessage(argv[0], *errout);
       return PARSE_HELP_PRINTED;
     }
   }
-  // check all other options
-  for( int i = 1; i < argc; ++i ) {
-    bool gov_return = get_opt_val( argv[i], &opt_name, &opt_val_str );
-    if( !gov_return ) {
-      if(procRank == 0)
-        print_bad_opt(i,argv,errout);
-      if( recogniseAllOptions() )
+  return PARSE_SUCCESSFUL;
+}
+
+CommandLineProcessor::EParseCommandLineReturn
+CommandLineProcessor::processArguments(int argc, char* argv[], std::ostream* errout) const
+{
+  std::string opt_name;
+  std::string opt_val_str;
+  const std::string echo_cl_opt = "echo-command-line";
+  const std::string pause_opt = "pause-for-debugging";
+  int procRank = GlobalMPISession::getRank();
+  for (int i = 1; i < argc; ++i) {
+    bool gov_return = get_opt_val(argv[i], &opt_name, &opt_val_str);
+    if (!gov_return) {
+      if (procRank == 0)
+        print_bad_opt(i, argv, errout);
+      if (recogniseAllOptions())
         return PARSE_UNRECOGNIZED_OPTION;
-      else {
+      else
         continue;
-      }
     }
-    if( opt_name == echo_cl_opt ) {
-      if(errout && procRank == 0) {
+    if (opt_name == echo_cl_opt) {
+      if (errout && procRank == 0) {
         *errout << "\nEchoing the command-line:\n\n";
-        for( int j = 0; j < argc; ++j )
+        for (int j = 0; j < argc; ++j)
           *errout << argv[j] << " ";
         *errout << "\n\n";
       }
       continue;
     }
-    if( opt_name == pause_opt ) {
+    if (opt_name == pause_opt) {
 #ifndef _WIN32
       Array<int> pids;
       pids.resize(GlobalMPISession::getNProc());
       int rank_pid = getpid();
-      GlobalMPISession::allGather(rank_pid,pids());
-      if(procRank == 0)
-        for (int k=0; k<GlobalMPISession::getNProc(); k++)
+      GlobalMPISession::allGather(rank_pid, pids());
+      if (procRank == 0)
+        for (int k = 0; k < GlobalMPISession::getNProc(); k++)
           std::cerr << "Rank " << k << " has PID " << pids[k] << std::endl;
 #endif
-      if(procRank == 0) {
+      if (procRank == 0) {
         std::cerr << "\nType 0 and press enter to continue : ";
         int dummy_int = 0;
         std::cin >> dummy_int;
@@ -307,21 +320,18 @@ CommandLineProcessor::parse(
       GlobalMPISession::barrier();
       continue;
     }
-    // Lookup the option (we had better find it!)
-    options_list_t::iterator  itr = options_list_.find(opt_name);
-    if( itr == options_list_.end() ) {
-      if(procRank == 0)
-        print_bad_opt(i,argv,errout);
-      if( recogniseAllOptions() )
+    options_list_t::iterator itr = options_list_.find(opt_name);
+    if (itr == options_list_.end()) {
+      if (procRank == 0)
+        print_bad_opt(i, argv, errout);
+      if (recogniseAllOptions())
         return PARSE_UNRECOGNIZED_OPTION;
       else
         continue;
     }
-    // Changed access to second value of std::map to not use overloaded arrow operator,
-    // otherwise this code will not compile on Janus (HKT, 12/01/2003)
     opt_val_val_t &opt_val_val = (*itr).second;
     opt_val_val.was_read = true;
-    switch( opt_val_val.opt_type ) {
+    switch (opt_val_val.opt_type) {
       case OPT_BOOL_TRUE:
         *(any_cast<bool*>(opt_val_val.opt_val)) = true;
         break;
@@ -329,61 +339,61 @@ CommandLineProcessor::parse(
         *(any_cast<bool*>(opt_val_val.opt_val)) = false;
         break;
       case OPT_INT:
-        *(any_cast<int*>(opt_val_val.opt_val)) = asSafe<int> (opt_val_str);
+        *(any_cast<int*>(opt_val_val.opt_val)) = asSafe<int>(opt_val_str);
         break;
       case OPT_LONG_INT:
-        *(any_cast<long int*>(opt_val_val.opt_val)) = asSafe<long int> (opt_val_str);
+        *(any_cast<long int*>(opt_val_val.opt_val)) = asSafe<long int>(opt_val_str);
         break;
       case OPT_SIZE_T:
-        *(any_cast<size_t *>(opt_val_val.opt_val)) = asSafe<size_t> (opt_val_str);
+        *(any_cast<size_t*>(opt_val_val.opt_val)) = asSafe<size_t>(opt_val_str);
         break;
       case OPT_LONG_LONG_INT:
-        *(any_cast<long long int*>(opt_val_val.opt_val)) = asSafe<long long int> (opt_val_str);
+        *(any_cast<long long int*>(opt_val_val.opt_val)) = asSafe<long long int>(opt_val_str);
         break;
       case OPT_DOUBLE:
-        *(any_cast<double*>(opt_val_val.opt_val)) = asSafe<double> (opt_val_str);
+        *(any_cast<double*>(opt_val_val.opt_val)) = asSafe<double>(opt_val_str);
         break;
       case OPT_FLOAT:
-        *(any_cast<float*>(opt_val_val.opt_val)) = asSafe<float> (opt_val_str);
+        *(any_cast<float*>(opt_val_val.opt_val)) = asSafe<float>(opt_val_str);
         break;
       case OPT_STRING:
         *(any_cast<std::string*>(opt_val_val.opt_val)) = remove_quotes(opt_val_str);
         break;
       case OPT_ENUM_INT:
-        if( !set_enum_value( i, argv, opt_name, any_cast<int>(opt_val_val.opt_val),
-            remove_quotes(opt_val_str), errout ) )
+        if (!set_enum_value(i, argv, opt_name, any_cast<int>(opt_val_val.opt_val),
+                            remove_quotes(opt_val_str), errout))
         {
           return PARSE_UNRECOGNIZED_OPTION;
         }
         break;
       default:
-        TEUCHOS_TEST_FOR_EXCEPT(true); // Local programming error only
+        TEUCHOS_TEST_FOR_EXCEPT(true);
     }
   }
-  // Look for options that were required but were not set
-  for(
-    options_list_t::const_iterator itr = options_list_.begin();
-    itr != options_list_.end();
-    ++itr
-    )
+  return PARSE_SUCCESSFUL;
+}
+
+CommandLineProcessor::EParseCommandLineReturn
+CommandLineProcessor::finalizeOptions(const char program_name[], std::ostream* errout) const
+{
+  for (options_list_t::const_iterator itr = options_list_.begin();
+       itr != options_list_.end(); ++itr)
   {
-    const opt_val_val_t   &opt_val_val  = (*itr).second;
-    if( opt_val_val.required && !opt_val_val.was_read ) {
-      const std::string     &opt_val_name = (*itr).first;
+    const opt_val_val_t &opt_val_val = (*itr).second;
+    if (opt_val_val.required && !opt_val_val.was_read) {
+      const std::string &opt_val_name = (*itr).first;
 #define CLP_ERR_MSG \
       "Error, the option --"<<opt_val_name<<" was required but was not set!"
-      if(errout)
-        *errout << std::endl << argv[0] << " : " << CLP_ERR_MSG << std::endl;
-      if( throwExceptions() ) {
-        TEUCHOS_TEST_FOR_EXCEPTION( true, ParseError, CLP_ERR_MSG );
+      if (errout)
+        *errout << std::endl << program_name << " : " << CLP_ERR_MSG << std::endl;
+      if (throwExceptions()) {
+        TEUCHOS_TEST_FOR_EXCEPTION(true, ParseError, CLP_ERR_MSG);
       }
       return PARSE_ERROR;
 #undef CLP_ERR_MSG
     }
   }
-  // Set the options of a default stream exists and if we are asked to
-  RCP<FancyOStream>
-    defaultOut = VerboseObjectBase::getDefaultOStream();
+  RCP<FancyOStream> defaultOut = VerboseObjectBase::getDefaultOStream();
   if (defaultOut.get() && addOutputSetupOptions_) {
     if (output_all_front_matter_ != output_all_front_matter_default_)
       defaultOut->setShowAllFrontMatter(output_all_front_matter_);

--- a/packages/teuchos/core/src/Teuchos_CommandLineProcessor.hpp
+++ b/packages/teuchos/core/src/Teuchos_CommandLineProcessor.hpp
@@ -595,6 +595,12 @@ private:
     ,std::ostream   *errout
     ) const;
 
+
+	  // Refactored helper functions extracted from parse()
+	  EParseCommandLineReturn checkForHelpOption(int argc, char* argv[], std::ostream* errout) const;
+	  EParseCommandLineReturn processArguments(int argc, char* argv[], std::ostream* errout) const;
+	  EParseCommandLineReturn finalizeOptions(const char program_name[], std::ostream* errout) const;
+
 public: // Hidden implementation stuff that clients should never see
 
   /// \class TimeMonitorSurrogate


### PR DESCRIPTION
This was performed with OpenHands with openrounter.ai model `openai/gpt-5` with the prompt:

----

TASK: Perform the Extract Function refactoring on the function Teuchos::CommandLineProcessor::parse() that is declared and defined in the files packages/teuchos/core/src/Teuchos_CommandLineProcessor.hpp and packages/teuchos/core/src/Teuchos_CommandLineProcessor.cpp. Extract out functions to make the code simpler and easier to maintain. Update the parent function to call the new functions.\n\nSTEPS: To perform this refactoring, perform the following steps:\n\n**Step 1:** Create the initial changes to the file\n\nPerform the Extract Function refactoring as described above and update the files Teuchos_CommandLineProcessor.hpp and
Teuchos_CommandLineProcessor.cpp\n\n**Step 2:** Get the object file Teuchos_CommandLineProcessor.cpp.o to build\n\nTo get feedback on the correctness of this refactoring, first get the object file Teuchos_CommandLineProcessor.cpp.o to build by running the command:\n\n  cd BUILDS/clang-19-simple && ninja
packages/teuchos/core/src/CMakeFile\ns/teuchoscore.dir/Teuchos_CommandLineProcessor.cpp.o\n\nLook at any compiler errors returned from that command and make fixes to those two files until the build errors are resolved.\n\n**Step 3:** Get the test executable TeuchosCore_CommandLineProcessor_test.exe to build\n\nAfter the object file Teuchos_CommandLineProcessor.cpp.o builds correctly from the previous step, get feedback on the linking of the test executable TeuchosCore_CommandLineProcessor_test.exe by running the build command:\n\n  cd BUILDS/clang-19-simple && ninja
packages/teuchos/core/test/CommandLineProcessor/TeuchosCore_CommandLineProcessor_test.exe\n\nFix any build or link errors by updating the source files.\n\n**Step 4:** Run the test TeuchosCore_CommandLineProcessor_test\n\nGet feedback on the correct functioning of the test by running the test using the command:\n\n  cd BUILDS/clang-19-simple && ctest -VV -R
TeuchosCore_CommandLineProcessor_test\n\nIf there are any test failures, update the source code to the files Teuchos_CommandLineProcessor.hpp and Teuchos_CommandLineProcessor.cpp and go back to Step 2 and Step 3 to get the object file and test executable to build before running the test again.\n\n**Step 5:** Summarize the results of the refactoring and testing\n\nOnce the test TeuchosCore_CommandLineProcessor_test runs and passes successfully, summarize the refactoring that was done and the testing that was done.\n\nAt this point, you are done.\n\n\n

----

Above, remove the newlines and repalce with a single space ' ' to reconstitute the actual prompt.  (And to make that human readable, repalce '\n' with newlines.)

This was verified locally!

NOTE: The cleaned up prompt is given at:

* https://cee-gitlab.sandia.gov/1424_asc_devops_research/ascdor-ai-tools/-/blob/2299febd9f7ba241c62aa23dcd26a1a2a190c130/prompts/example_prompts/teuchos-clp-parse-ef.txt

You can pass that in with the `-f` argument to openhands.
