### PR TITLE
Extract function parseCheckForHelpOpt() refactoring performed by codex + gpt-oss-20b - 2025-09-07b

### DIFF
--- a/packages/teuchos/core/src/Teuchos_CommandLineProcessor.cpp
+++ b/packages/teuchos/core/src/Teuchos_CommandLineProcessor.cpp
@@ -261,13 +261,8 @@ CommandLineProcessor::parse(
 
   // check for help options before any others as we modify
   // the values afterwards
-  for( int i = 1; i < argc; ++i ) {
-    bool gov_return = get_opt_val( argv[i], &opt_name, &opt_val_str );
-    if( gov_return && opt_name == help_opt ) {
-      if(errout) printHelpMessage( argv[0], *errout );
-      return PARSE_HELP_PRINTED;
-    }
-  }
+  EParseCommandLineReturn help_ret = parseCheckForHelpOpt(argc, argv, errout);
+  if (help_ret != PARSE_SUCCESSFUL) return help_ret;
   // check all other options
   for( int i = 1; i < argc; ++i ) {
     bool gov_return = get_opt_val( argv[i], &opt_name, &opt_val_str );
@@ -396,6 +391,29 @@ CommandLineProcessor::parse(
     if (output_to_root_rank_only_ != output_to_root_rank_only_default_)
       defaultOut->setOutputToRootOnly(output_to_root_rank_only_);
     RCPNodeTracer::setPrintRCPNodeStatisticsOnExit(print_rcpnode_statistics_on_exit_);
+  }
+  return PARSE_SUCCESSFUL;
+}
+
+// -----------------------------------------------------------------------------
+// Helper that checks for the help option.
+// -----------------------------------------------------------------------------
+CommandLineProcessor::EParseCommandLineReturn
+CommandLineProcessor::parseCheckForHelpOpt(
+  int             argc,
+  char*           argv[],
+  std::ostream*   errout
+  ) const
+{
+  std::string        opt_name;
+  std::string        opt_val_str;
+  const std::string  help_opt = "help";
+  for( int i = 1; i < argc; ++i ) {
+    bool gov_return = get_opt_val( argv[i], &opt_name, &opt_val_str );
+    if( gov_return && opt_name == help_opt ) {
+      if(errout) printHelpMessage( argv[0], *errout );
+      return PARSE_HELP_PRINTED;
+    }
   }
   return PARSE_SUCCESSFUL;
 }

--- a/packages/teuchos/core/src/Teuchos_CommandLineProcessor.hpp
+++ b/packages/teuchos/core/src/Teuchos_CommandLineProcessor.hpp
@@ -378,6 +378,26 @@ public:
     ,std::ostream   *errout = &std::cerr
     ) const;
 
+  /**
+   * @brief Check for the help option and print help if requested.
+   *
+   * This helper extracts the logic that scans for a "help" option from
+   * command line arguments.  It is public so that it can be unit-tested
+   * independently.
+   *
+   * @param argc Number of arguments.
+   * @param argv Argument vector.
+   * @param errout Optional error output stream.
+   * @return {@link EParseCommandLineReturn::PARSE_HELP_PRINTED} if the
+   *   help message was printed; otherwise {@link
+   *   EParseCommandLineReturn::PARSE_SUCCESSFUL}.
+   */
+  EParseCommandLineReturn parseCheckForHelpOpt(
+    int             argc
+    ,char*          argv[]
+    ,std::ostream   *errout
+    ) const;
+
   //@}
 
   //! @name Miscellaneous


### PR DESCRIPTION
This was produced in one shot with codex and the gpt-oss-20b model running on my
machine 'rabai25':

```
codex --full-auto -c model_provider=llama --model=gpt-oss-20b \
  "$(/mounted_from_host/ascdor-ai-tools/prompts/refactoring/extract_function/generate-extract-func-prompt.py \
  --def-file 'packages/teuchos/core/src/Teuchos_CommandLineProcessor.cpp' \
  --decl-file 'packages/teuchos/core/src/Teuchos_CommandLineProcessor.hpp' \
  -p 'Teuchos::CommandLineProcessor::parse' \
  -l 264-270 \
  -n parseCheckForHelpOpt \
  -b BUILDS/clang-19-simple \
  -o packages/teuchos/core/src/CMakeFiles/teuchoscore.dir/Teuchos_CommandLineProcessor.cpp.o \
  --test-exec packages/teuchos/core/test/CommandLineProcessor/TeuchosCore_CommandLineProcessor_test.exe \
  -t TeuchosCore_CommandLineProcessor_test_MPI_1)"
```