### PR TITLE
Extract function parsePauseIfAsked using Codex + gpt-oss-20b - 2025-09-07a

### DIFF
--- a/packages/teuchos/core/src/Teuchos_CommandLineProcessor.cpp
+++ b/packages/teuchos/core/src/Teuchos_CommandLineProcessor.cpp
@@ -289,26 +289,9 @@ CommandLineProcessor::parse(
       }
       continue;
     }
-    if( opt_name == pause_opt ) {
-#ifndef _WIN32
-      Array<int> pids;
-      pids.resize(GlobalMPISession::getNProc());
-      int rank_pid = getpid();
-      GlobalMPISession::allGather(rank_pid,pids());
-      if(procRank == 0)
-        for (int k=0; k<GlobalMPISession::getNProc(); k++)
-          std::cerr << "Rank " << k << " has PID " << pids[k] << std::endl;
-#endif
-      if(procRank == 0) {
-        std::cerr << "\nType 0 and press enter to continue : ";
-        int dummy_int = 0;
-        std::cin >> dummy_int;
-      }
-      GlobalMPISession::barrier();
-      continue;
-    }
-    // Lookup the option (we had better find it!)
-    options_list_t::iterator  itr = options_list_.find(opt_name);
+    if( parsePauseIfAsked(opt_name, procRank, pause_opt) ) continue;
+  // Lookup the option (we had better find it!)
+  options_list_t::iterator  itr = options_list_.find(opt_name);
     if( itr == options_list_.end() ) {
       if(procRank == 0)
         print_bad_opt(i,argv,errout);
@@ -850,5 +833,30 @@ CommandLineProcessor::getRawTimeMonitorSurrogate()
   return timeMonitorSurrogate;
 }
 
+
+// -----------------------------------------------------------------------------
+// Implementation of the extracted pause handling helper.
+bool CommandLineProcessor::parsePauseIfAsked(const std::string &opt_name,
+                                              int procRank,
+                                              const std::string &pause_opt) const {
+  if( opt_name != pause_opt ) return false;
+  // Original pause handling block
+#ifndef _WIN32
+  Array<int> pids;
+  pids.resize(GlobalMPISession::getNProc());
+  int rank_pid = getpid();
+  GlobalMPISession::allGather(rank_pid,pids());
+  if(procRank == 0)
+    for (int k=0; k<GlobalMPISession::getNProc(); k++)
+      std::cerr << "Rank " << k << " has PID " << pids[k] << std::endl;
+#endif
+  if(procRank == 0) {
+    std::cerr << "\nType 0 and press enter to continue : ";
+    int dummy_int = 0;
+    std::cin >> dummy_int;
+  }
+  GlobalMPISession::barrier();
+  return true;
+}
 
 } // end namespace Teuchos

--- a/packages/teuchos/core/src/Teuchos_CommandLineProcessor.cpp
+++ b/packages/teuchos/core/src/Teuchos_CommandLineProcessor.cpp
@@ -290,8 +290,8 @@ CommandLineProcessor::parse(
       continue;
     }
     if( parsePauseIfAsked(opt_name, procRank, pause_opt) ) continue;
-  // Lookup the option (we had better find it!)
-  options_list_t::iterator  itr = options_list_.find(opt_name);
+    // Lookup the option (we had better find it!)
+    options_list_t::iterator  itr = options_list_.find(opt_name);
     if( itr == options_list_.end() ) {
       if(procRank == 0)
         print_bad_opt(i,argv,errout);

--- a/packages/teuchos/core/src/Teuchos_CommandLineProcessor.hpp
+++ b/packages/teuchos/core/src/Teuchos_CommandLineProcessor.hpp
@@ -377,6 +377,22 @@ public:
     ,char*          argv[]
     ,std::ostream   *errout = &std::cerr
     ) const;
+  /**
+   * @brief Handle the --pause-for-debugging option.
+   *
+   * This helper extracts the logic that prints process IDs and waits for
+   * user input when the pause option is encountered.  It is exposed as a
+   * public member function to allow unit tests to exercise it directly.
+   *
+   * @param opt_name   The option name being processed.
+   * @param procRank   Current MPI rank.
+   * @param pause_opt  The string value of the pause option.
+   * @return true if the pause option was processed and the caller should
+   *   continue to the next command-line argument.
+   */
+  bool parsePauseIfAsked(const std::string &opt_name,
+                         int procRank,
+                         const std::string &pause_opt) const;
 
   //@}
 


### PR DESCRIPTION
This was produced by running the following inside of the codex container:

```
codex -a never -s workspace-write -c model_provider=llama-cpp-gpt-oss-20b --model=gpt-oss-20b \
  "$(/mounted_from_host/ascdor-ai-tools/prompts/refactoring/extract_function/generate-extract-func-prompt.py \
  --def-file 'packages/teuchos/core/src/Teuchos_CommandLineProcessor.cpp' \
  --decl-file 'packages/teuchos/core/src/Teuchos_CommandLineProcessor.hpp' \
  -p 'Teuchos::CommandLineProcessor::parse' \
  -l 292-309 \
  -n parsePauseIfAsked \
  -b BUILDS/clang-19-simple \
  --obj-target packages/teuchos/core/src/CMakeFiles/teuchoscore.dir/Teuchos_CommandLineProcessor.cpp.o \
  --test-target packages/teuchos/core/test/CommandLineProcessor/TeuchosCore_CommandLineProcessor_test.exe \
  --test TeuchosCore_CommandLineProcessor_test_MPI_1)"
```

This passed the build and tests.

This is not a completely simple refactoring due to the usage of the `continue` statement.
