### PR TITLE
Extract Function refactoring of Tpetra::CrsMatrix::transferAndFillComplete() with codex + gpt-5-medium - 2025-09-07b

### DIFF
--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -30,6 +30,11 @@
 
 
 #include <memory> // std::shared_ptr
+#include <string>
+
+// Forward declarations to avoid heavy includes in the declaration header.
+namespace Tpetra { namespace Details { class CommRequest; } }
+namespace Teuchos { class TimeMonitor; }
 
 namespace Tpetra {
 
@@ -3496,6 +3501,24 @@ public:
                            const Teuchos::RCP<const map_type>& domainMap,
                            const Teuchos::RCP<const map_type>& rangeMap,
                            const Teuchos::RCP<Teuchos::ParameterList>& params) const;
+
+    // Extracted helper to expose parameter processing and initial
+    // setup used by transferAndFillComplete. Public for testing.
+    void
+    transferAndFillComplete_getCallersParamters(
+      bool& isMM,
+      const Teuchos::RCP<Teuchos::ParameterList>& params,
+      const int mm_optimization_core_count,
+      const bool reverseMode,
+      const ::Tpetra::Details::Transfer<LocalOrdinal, GlobalOrdinal, Node>& rowTransfer,
+      std::shared_ptr< ::Tpetra::Details::CommRequest>& iallreduceRequest,
+      int& reduced_mismatch
+#ifdef HAVE_TPETRA_MMM_TIMINGS
+      , std::string& label,
+      std::string& prefix,
+      Teuchos::RCP<Teuchos::TimeMonitor>& timerAll
+#endif
+    ) const;
 
 
   private:

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -7739,44 +7739,34 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
       auto & slist = params->sublist("matrixmatrix: kernel params",false);
       isMM = slist.get("isMatrixMatrix_TransferAndFillComplete",false);
       mm_optimization_core_count = slist.get("MM_TAFC_OptimizationCoreCount",mm_optimization_core_count);
-
-      overrideAllreduce = slist.get("MM_TAFC_OverrideAllreduceCheck",false);
-      if(getComm()->getSize() < mm_optimization_core_count && isMM)   isMM = false;
-      if(reverseMode) isMM = false;
+      // overrideAllreduce and the remaining setup are handled below
+      // via transferAndFillComplete_getCallersParamters.
     }
 
-   // Only used in the sparse matrix-matrix multiply (isMM) case.
-   std::shared_ptr< ::Tpetra::Details::CommRequest> iallreduceRequest;
-   int mismatch = 0;
-   int reduced_mismatch = 0;
-   if (isMM && !overrideAllreduce) {
-
-     // Test for pathological matrix transfer
-     const bool source_vals = ! getGraph ()->getImporter ().is_null();
-     const bool target_vals = ! (rowTransfer.getExportLIDs ().size() == 0 ||
-                                 rowTransfer.getRemoteLIDs ().size() == 0);
-     mismatch = (source_vals != target_vals) ? 1 : 0;
-     iallreduceRequest =
-       ::Tpetra::Details::iallreduce (mismatch, reduced_mismatch,
-                                      Teuchos::REDUCE_MAX, * (getComm ()));
-   }
-
+    // Only used in the sparse matrix-matrix multiply (isMM) case.
+    std::shared_ptr< ::Tpetra::Details::CommRequest> iallreduceRequest;
+    int reduced_mismatch = 0;
 #ifdef HAVE_TPETRA_MMM_TIMINGS
     using Teuchos::TimeMonitor;
     std::string label;
-    if(!params.is_null())
-        label = params->get("Timer Label",label);
-    std::string prefix = std::string("Tpetra ")+ label + std::string(": ");
-    std::string tlstr;
-    {
-        std::ostringstream os;
-        if(isMM) os<<":MMOpt";
-        else os<<":MMLegacy";
-        tlstr = os.str();
-    }
-
-    Teuchos::TimeMonitor MMall(*TimeMonitor::getNewTimer(prefix + std::string("TAFC All") +tlstr ));
+    std::string prefix;
+    Teuchos::RCP<TimeMonitor> MMall;
 #endif
+
+    this->transferAndFillComplete_getCallersParamters(
+      isMM,
+      params,
+      mm_optimization_core_count,
+      reverseMode,
+      rowTransfer,
+      iallreduceRequest,
+      reduced_mismatch
+#ifdef HAVE_TPETRA_MMM_TIMINGS
+      , label,
+      prefix,
+      MMall
+#endif
+    );
 
     // Make sure that the input argument rowTransfer is either an
     // Import or an Export.  Import and Export are the only two
@@ -9117,6 +9107,64 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
       std::cerr << os.str ();
     }
   } //transferAndFillComplete
+
+
+  template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+  void
+  CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
+  transferAndFillComplete_getCallersParamters(
+      bool& isMM,
+      const Teuchos::RCP<Teuchos::ParameterList>& params,
+      const int mm_optimization_core_count,
+      const bool reverseMode,
+      const ::Tpetra::Details::Transfer<LocalOrdinal, GlobalOrdinal, Node>& rowTransfer,
+      std::shared_ptr< ::Tpetra::Details::CommRequest>& iallreduceRequest,
+      int& reduced_mismatch
+#ifdef HAVE_TPETRA_MMM_TIMINGS
+      , std::string& label,
+      std::string& prefix,
+      Teuchos::RCP<Teuchos::TimeMonitor>& timerAll
+#endif
+    ) const
+  {
+    bool overrideAllreduce_local = false;
+    if (! params.is_null ()) {
+      auto & slist = params->sublist("matrixmatrix: kernel params",false);
+      overrideAllreduce_local = slist.get("MM_TAFC_OverrideAllreduceCheck",false);
+      if(getComm()->getSize() < mm_optimization_core_count && isMM)   isMM = false;
+      if(reverseMode) isMM = false;
+    }
+
+    int mismatch = 0;
+    reduced_mismatch = 0;
+    if (isMM && !overrideAllreduce_local) {
+      const bool source_vals = ! getGraph ()->getImporter ().is_null();
+      const bool target_vals = ! (rowTransfer.getExportLIDs ().size() == 0 ||
+                                  rowTransfer.getRemoteLIDs ().size() == 0);
+      mismatch = (source_vals != target_vals) ? 1 : 0;
+      iallreduceRequest =
+        ::Tpetra::Details::iallreduce (mismatch, reduced_mismatch,
+                                       Teuchos::REDUCE_MAX, * (getComm ()));
+    } else {
+      iallreduceRequest.reset();
+    }
+
+#ifdef HAVE_TPETRA_MMM_TIMINGS
+    if(!params.is_null())
+      label = params->get("Timer Label",label);
+    prefix = std::string("Tpetra ")+ label + std::string(": ");
+    std::string tlstr;
+    {
+      std::ostringstream os;
+      if(isMM) os<<":MMOpt";
+      else os<<":MMLegacy";
+      tlstr = os.str();
+    }
+    timerAll = Teuchos::rcp(new Teuchos::TimeMonitor(*Teuchos::TimeMonitor::getNewTimer(prefix + std::string("TAFC All") + tlstr )));
+#else
+    (void)rowTransfer; // silence unused warnings in non-timing builds
+#endif
+  }
 
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>


### PR DESCRIPTION
This was done automatically using:

```bash
codex -a never -s workspace-write --model=gpt-5 \
  "$(/mounted_from_host/ascdor-ai-tools/prompts/refactoring/extract_function/generate-extract-func-prompt.py \
  --def-file 'packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp' \
  --decl-file 'packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp' \
  -p 'Tpetra::CrsMatrix:transferAndFillComplete' \
  -l 7743-7780 \
  -n transferAndFillComplete_getCallersParamters \
  -b BUILDS/clang-19-simple \
  --obj-target packages/tpetra/core/src/CMakeFiles/tpetra.dir/Tpetra_CrsMatrix_DOUBLE_DOUBLE_INT_LONG_LONG_SERIAL.cpp.o \
  --test-target packages/tpetra/core/test/CrsMatrix/TpetraCore_CrsMatrix_UnitTests.exe \
  --test TpetraCore_CrsMatrix_UnitTests_MPI_4)"
```

I have not fully examined the result yet, but it got the basics correct, including figuring out the forward declarations:

```c++
  namespace Tpetra { namespace Details { class CommRequest; } }
  namespace Teuchos { class TimeMonitor; }
```

This is a newer version of Trilinos so you can't compare with my pervious manual refactoring:

* https://github.com/bartlettroscoe/MyTrilinos/pull/4

