### PR TITLE
Extract Function refactoring of Tpetra::CrsMatrix::transferAndFillComplete() with codex + gpt-5-medium - 2025-09-07c

### DIFF
--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -40,6 +40,9 @@ namespace Tpetra {
   // Forward declaration for CrsMatrix::swap() test
   template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node> class crsMatrix_Swap_Tester;
 
+  // Forward declaration for Details::CommRequest used by helper API
+  namespace Details { class CommRequest; }
+
   /// \brief Nonmember CrsMatrix constructor that fuses Import and fillComplete().
   /// \relatesalso CrsMatrix
   /// \tparam CrsMatrixType A specialization of CrsMatrix.
@@ -3509,6 +3512,26 @@ public:
                            const Teuchos::RCP<const map_type>& domainMap,
                            const Teuchos::RCP<const map_type>& rangeMap,
                            const Teuchos::RCP<Teuchos::ParameterList>& params) const;
+
+
+    /// \brief Extracted helper for transferAndFillComplete: get caller parameters
+    ///
+    /// Public for testing. Computes flags and parameters used by
+    /// transferAndFillComplete based on input params and rowTransfer.
+    void
+    transferAndFillComplete_getCallersParamters (
+      const Teuchos::RCP<Teuchos::ParameterList>& params,
+      const ::Tpetra::Details::Transfer<LocalOrdinal, GlobalOrdinal, Node>& rowTransfer,
+      bool & isMM,
+      bool & reverseMode,
+      bool & restrictComm,
+      int  & mm_optimization_core_count,
+      Teuchos::RCP<Teuchos::ParameterList> & matrixparams,
+      bool & overrideAllreduce,
+      bool & useKokkosPath,
+      std::shared_ptr< ::Tpetra::Details::CommRequest> & iallreduceRequest,
+      int  & mismatch,
+      int  & reduced_mismatch) const;
 
 
   private:

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -7740,44 +7740,22 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     //
     // Get the caller's parameters
     //
-    bool isMM = false; // optimize for matrix-matrix ops.
-    bool reverseMode = false; // Are we in reverse mode?
-    bool restrictComm = false; // Do we need to restrict the communicator?
-
-    int mm_optimization_core_count =
-      Behavior::TAFC_OptimizationCoreCount();
-    RCP<ParameterList> matrixparams; // parameters for the destination matrix
-    bool overrideAllreduce = false;
-    bool useKokkosPath = false;
-    if (! params.is_null ()) {
-      matrixparams = sublist (params, "CrsMatrix");
-      reverseMode = params->get ("Reverse Mode", reverseMode);
-      useKokkosPath = params->get ("TAFC: use kokkos path", useKokkosPath);
-      restrictComm = params->get ("Restrict Communicator", restrictComm);
-      auto & slist = params->sublist("matrixmatrix: kernel params",false);
-      isMM = slist.get("isMatrixMatrix_TransferAndFillComplete",false);
-      mm_optimization_core_count = slist.get("MM_TAFC_OptimizationCoreCount",mm_optimization_core_count);
-
-      overrideAllreduce = slist.get("MM_TAFC_OverrideAllreduceCheck",false);
-      if(getComm()->getSize() < mm_optimization_core_count && isMM)   isMM = false;
-      if(reverseMode) isMM = false;
-    }
-
-   // Only used in the sparse matrix-matrix multiply (isMM) case.
-   std::shared_ptr< ::Tpetra::Details::CommRequest> iallreduceRequest;
-   int mismatch = 0;
-   int reduced_mismatch = 0;
-   if (isMM && !overrideAllreduce) {
-
-     // Test for pathological matrix transfer
-     const bool source_vals = ! getGraph ()->getImporter ().is_null();
-     const bool target_vals = ! (rowTransfer.getExportLIDs ().size() == 0 ||
-                                 rowTransfer.getRemoteLIDs ().size() == 0);
-     mismatch = (source_vals != target_vals) ? 1 : 0;
-     iallreduceRequest =
-       ::Tpetra::Details::iallreduce (mismatch, reduced_mismatch,
-                                      Teuchos::REDUCE_MAX, * (getComm ()));
-   }
+    bool isMM;
+    bool reverseMode;
+    bool restrictComm;
+    int mm_optimization_core_count;
+    RCP<ParameterList> matrixparams;
+    bool overrideAllreduce;
+    bool useKokkosPath;
+    std::shared_ptr< ::Tpetra::Details::CommRequest> iallreduceRequest;
+    int mismatch;
+    int reduced_mismatch;
+    this->transferAndFillComplete_getCallersParamters (
+      params, rowTransfer,
+      isMM, reverseMode, restrictComm,
+      mm_optimization_core_count, matrixparams,
+      overrideAllreduce, useKokkosPath,
+      iallreduceRequest, mismatch, reduced_mismatch);
 
 #ifdef HAVE_TPETRA_MMM_TIMINGS
     using Teuchos::TimeMonitor;
@@ -9135,6 +9113,71 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
       std::cerr << os.str ();
     }
   } //transferAndFillComplete
+
+
+  template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+  void
+  CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
+  transferAndFillComplete_getCallersParamters (
+      const Teuchos::RCP<Teuchos::ParameterList>& params,
+      const ::Tpetra::Details::Transfer<LocalOrdinal, GlobalOrdinal, Node>& rowTransfer,
+      bool & isMM,
+      bool & reverseMode,
+      bool & restrictComm,
+      int  & mm_optimization_core_count,
+      Teuchos::RCP<Teuchos::ParameterList> & matrixparams,
+      bool & overrideAllreduce,
+      bool & useKokkosPath,
+      std::shared_ptr< ::Tpetra::Details::CommRequest> & iallreduceRequest,
+      int  & mismatch,
+      int  & reduced_mismatch) const
+  {
+    using Details::Behavior;
+    using Teuchos::ParameterList;
+    using Teuchos::RCP;
+
+    // Default values
+    isMM = false; // optimize for matrix-matrix ops.
+    reverseMode = false; // Are we in reverse mode?
+    restrictComm = false; // Do we need to restrict the communicator?
+
+    mm_optimization_core_count = Behavior::TAFC_OptimizationCoreCount();
+    matrixparams = Teuchos::null; // parameters for the destination matrix
+    overrideAllreduce = false;
+    useKokkosPath = false;
+
+    if (! params.is_null ()) {
+      matrixparams = sublist (params, "CrsMatrix");
+      reverseMode = params->get ("Reverse Mode", reverseMode);
+      useKokkosPath = params->get ("TAFC: use kokkos path", useKokkosPath);
+      restrictComm = params->get ("Restrict Communicator", restrictComm);
+      auto & slist = params->sublist("matrixmatrix: kernel params",false);
+      isMM = slist.get("isMatrixMatrix_TransferAndFillComplete",false);
+      mm_optimization_core_count = slist.get(
+        "MM_TAFC_OptimizationCoreCount", mm_optimization_core_count);
+
+      overrideAllreduce = slist.get("MM_TAFC_OverrideAllreduceCheck",false);
+      if (getComm()->getSize() < mm_optimization_core_count && isMM)
+        isMM = false;
+      if (reverseMode) isMM = false;
+    }
+
+    // Only used in the sparse matrix-matrix multiply (isMM) case.
+    iallreduceRequest.reset();
+    mismatch = 0;
+    reduced_mismatch = 0;
+    if (isMM && !overrideAllreduce) {
+
+      // Test for pathological matrix transfer
+      const bool source_vals = ! getGraph ()->getImporter ().is_null();
+      const bool target_vals = ! (rowTransfer.getExportLIDs ().size() == 0 ||
+                                  rowTransfer.getRemoteLIDs ().size() == 0);
+      mismatch = (source_vals != target_vals) ? 1 : 0;
+      iallreduceRequest =
+        ::Tpetra::Details::iallreduce (mismatch, reduced_mismatch,
+                                       Teuchos::REDUCE_MAX, * (getComm ()));
+    }
+  }
 
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>


### PR DESCRIPTION
This was created off of the correct base commit to allow a comparison for:

* https://github.com/bartlettroscoe/MyTrilinos/pull/4

This was produced with Codex + gpt-5-medium using:

```
codex exec -s workspace-write --model=gpt-5 \
  "$(/mounted_from_host/ascdor-ai-tools/prompts/refactoring/extract_function/generate-extract-func-prompt.py \
  --def-file 'packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp' \
  --decl-file 'packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp' \
  -p 'Tpetra::CrsMatrix:transferAndFillComplete' \
  -l 7743-7780 \
  -n transferAndFillComplete_getCallersParamters \
  -b BUILDS/clang-19-simple \
  --obj-target packages/tpetra/core/src/CMakeFiles/tpetra.dir/Tpetra_CrsMatrix_DOUBLE_DOUBLE_INT_LONG_LONG_SERIAL.cpp.o \
  --test-target packages/tpetra/core/test/CrsMatrix/TpetraCore_CrsMatrix_UnitTests.exe \
  --test TpetraCore_CrsMatrix_UnitTests_MPI_4)"
```

This built and the test passed!

This took 4m4.140s to complete.  (The manual refactoring too me over 1 hour.)
