### PR TITLE
Extract Function refactoring of Tpetra::CrsMatrix::transferAndFillComplete() with codex + gpt-oss-120b - 2025-09-07e

### DIFF
--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -37,6 +37,12 @@
 
 namespace Tpetra {
 
+// Forward declaration of the non‑templated communication request used by
+// transferAndFillComplete.  The full definition lives in
+// Tpetra_Details_iallreduce.hpp, which is included by the corresponding .def
+// file.
+namespace Details { class CommRequest; }
+
   // Forward declaration for CrsMatrix::swap() test
   template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node> class crsMatrix_Swap_Tester;
 
@@ -3539,6 +3545,22 @@ public:
                              const Teuchos::RCP<const map_type>& domainMap = Teuchos::null,
                              const Teuchos::RCP<const map_type>& rangeMap = Teuchos::null,
                              const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null) const;
+
+    // Extract caller's parameters for transferAndFillComplete.
+    void
+    transferAndFillComplete_getCallersParamters (
+        const Teuchos::RCP<Teuchos::ParameterList>& params,
+        const ::Tpetra::Details::Transfer<LocalOrdinal, GlobalOrdinal, Node>& rowTransfer,
+        bool& isMM,
+        bool& reverseMode,
+        bool& restrictComm,
+        int& mm_optimization_core_count,
+        Teuchos::RCP<Teuchos::ParameterList>& matrixparams,
+        bool& overrideAllreduce,
+        bool& useKokkosPath,
+    std::shared_ptr< ::Tpetra::Details::CommRequest>& iallreduceRequest,
+        int& mismatch,
+        int& reduced_mismatch) const;
 
     /// \brief Common implementation detail of insertGlobalValues and
     ///   insertGlobalValuesFiltered.

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -7737,47 +7737,21 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
       std::cerr << os.str();
     }
 
-    //
-    // Get the caller's parameters
-    //
-    bool isMM = false; // optimize for matrix-matrix ops.
-    bool reverseMode = false; // Are we in reverse mode?
-    bool restrictComm = false; // Do we need to restrict the communicator?
-
-    int mm_optimization_core_count =
-      Behavior::TAFC_OptimizationCoreCount();
-    RCP<ParameterList> matrixparams; // parameters for the destination matrix
-    bool overrideAllreduce = false;
-    bool useKokkosPath = false;
-    if (! params.is_null ()) {
-      matrixparams = sublist (params, "CrsMatrix");
-      reverseMode = params->get ("Reverse Mode", reverseMode);
-      useKokkosPath = params->get ("TAFC: use kokkos path", useKokkosPath);
-      restrictComm = params->get ("Restrict Communicator", restrictComm);
-      auto & slist = params->sublist("matrixmatrix: kernel params",false);
-      isMM = slist.get("isMatrixMatrix_TransferAndFillComplete",false);
-      mm_optimization_core_count = slist.get("MM_TAFC_OptimizationCoreCount",mm_optimization_core_count);
-
-      overrideAllreduce = slist.get("MM_TAFC_OverrideAllreduceCheck",false);
-      if(getComm()->getSize() < mm_optimization_core_count && isMM)   isMM = false;
-      if(reverseMode) isMM = false;
-    }
-
-   // Only used in the sparse matrix-matrix multiply (isMM) case.
-   std::shared_ptr< ::Tpetra::Details::CommRequest> iallreduceRequest;
-   int mismatch = 0;
-   int reduced_mismatch = 0;
-   if (isMM && !overrideAllreduce) {
-
-     // Test for pathological matrix transfer
-     const bool source_vals = ! getGraph ()->getImporter ().is_null();
-     const bool target_vals = ! (rowTransfer.getExportLIDs ().size() == 0 ||
-                                 rowTransfer.getRemoteLIDs ().size() == 0);
-     mismatch = (source_vals != target_vals) ? 1 : 0;
-     iallreduceRequest =
-       ::Tpetra::Details::iallreduce (mismatch, reduced_mismatch,
-                                      Teuchos::REDUCE_MAX, * (getComm ()));
-   }
+    // Get the caller's parameters (extracted to helper)
+    bool isMM;
+    bool reverseMode;
+    bool restrictComm;
+    int mm_optimization_core_count;
+    Teuchos::RCP<Teuchos::ParameterList> matrixparams;
+    bool overrideAllreduce;
+    bool useKokkosPath;
+    std::shared_ptr< ::Tpetra::Details::CommRequest> iallreduceRequest;
+    int mismatch;
+    int reduced_mismatch;
+    transferAndFillComplete_getCallersParamters(params, rowTransfer,
+        isMM, reverseMode, restrictComm, mm_optimization_core_count,
+        matrixparams, overrideAllreduce, useKokkosPath,
+        iallreduceRequest, mismatch, reduced_mismatch);
 
 #ifdef HAVE_TPETRA_MMM_TIMINGS
     using Teuchos::TimeMonitor;
@@ -9147,6 +9121,61 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
                          const Teuchos::RCP<Teuchos::ParameterList>& params) const
   {
     transferAndFillComplete (destMatrix, importer, Teuchos::null, domainMap, rangeMap, params);
+  }
+
+  // Extract the caller's parameters for transferAndFillComplete.
+  template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+  void
+  CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
+  transferAndFillComplete_getCallersParamters (
+      const Teuchos::RCP<Teuchos::ParameterList>& params,
+      const ::Tpetra::Details::Transfer<LocalOrdinal, GlobalOrdinal, Node>& rowTransfer,
+      bool& isMM,
+      bool& reverseMode,
+      bool& restrictComm,
+      int& mm_optimization_core_count,
+      Teuchos::RCP<Teuchos::ParameterList>& matrixparams,
+      bool& overrideAllreduce,
+      bool& useKokkosPath,
+      std::shared_ptr< ::Tpetra::Details::CommRequest>& iallreduceRequest,
+      int& mismatch,
+      int& reduced_mismatch) const
+  {
+    using Details::Behavior;
+    // Initialize defaults
+    isMM = false;
+    reverseMode = false;
+    restrictComm = false;
+    mm_optimization_core_count = Behavior::TAFC_OptimizationCoreCount();
+    matrixparams = Teuchos::null;
+    overrideAllreduce = false;
+    useKokkosPath = false;
+    iallreduceRequest.reset();
+    mismatch = 0;
+    reduced_mismatch = 0;
+
+    if (! params.is_null ()) {
+      matrixparams = sublist (params, "CrsMatrix");
+      reverseMode = params->get ("Reverse Mode", reverseMode);
+      useKokkosPath = params->get ("TAFC: use kokkos path", useKokkosPath);
+      restrictComm = params->get ("Restrict Communicator", restrictComm);
+      auto & slist = params->sublist("matrixmatrix: kernel params",false);
+      isMM = slist.get("isMatrixMatrix_TransferAndFillComplete",false);
+      mm_optimization_core_count = slist.get("MM_TAFC_OptimizationCoreCount",mm_optimization_core_count);
+      overrideAllreduce = slist.get("MM_TAFC_OverrideAllreduceCheck",false);
+      if(getComm()->getSize() < mm_optimization_core_count && isMM) isMM = false;
+      if(reverseMode) isMM = false;
+    }
+
+    // Only used in the sparse matrix-matrix multiply (isMM) case.
+    if (isMM && !overrideAllreduce) {
+      const bool source_vals = ! getGraph ()->getImporter ().is_null();
+      const bool target_vals = ! (rowTransfer.getExportLIDs ().size() == 0 ||
+                                  rowTransfer.getRemoteLIDs ().size() == 0);
+      mismatch = (source_vals != target_vals) ? 1 : 0;
+      iallreduceRequest = ::Tpetra::Details::iallreduce (mismatch, reduced_mismatch,
+                                 Teuchos::REDUCE_MAX, *(getComm()));
+    }
   }
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>


### PR DESCRIPTION
This used the following command:

```
codex -a never -s workspace-write -c model_provider=llama-cpp-gpt-oss-120b --model=gpt-oss-120b \
  "$(/mounted_from_host/ascdor-ai-tools/prompts/refactoring/extract_function/generate-extract-func-prompt.py \
  --def-file 'packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp' \
  --decl-file 'packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp' \
  -p 'Tpetra::CrsMatrix:transferAndFillComplete' \
  -l 7743-7780 \
  -n transferAndFillComplete_getCallersParamters \
  -b BUILDS/clang-19-simple \
  --obj-target packages/tpetra/core/src/CMakeFiles/tpetra.dir/Tpetra_CrsMatrix_DOUBLE_DOUBLE_INT_LONG_LONG_SERIAL.cpp.o \
  --test-target packages/tpetra/core/test/CrsMatrix/TpetraCore_CrsMatrix_UnitTests.exe \
  --test TpetraCore_CrsMatrix_UnitTests_MPI_4)"
```

This even produced the tricky forward declaration of  Tpetra::Details::CommRequest in the decl file!

This is a big deal that it was able to do this refactoring!
