### PR TITLE
Extract function parsePauseIfAsked using Codex + gpt-oss-20b - 2025-09-08a

### DIFF
--- a/packages/teuchos/core/src/Teuchos_CommandLineProcessor.cpp
+++ b/packages/teuchos/core/src/Teuchos_CommandLineProcessor.cpp
@@ -290,21 +290,7 @@ CommandLineProcessor::parse(
       continue;
     }
     if( opt_name == pause_opt ) {
-#ifndef _WIN32
-      Array<int> pids;
-      pids.resize(GlobalMPISession::getNProc());
-      int rank_pid = getpid();
-      GlobalMPISession::allGather(rank_pid,pids());
-      if(procRank == 0)
-        for (int k=0; k<GlobalMPISession::getNProc(); k++)
-          std::cerr << "Rank " << k << " has PID " << pids[k] << std::endl;
-#endif
-      if(procRank == 0) {
-        std::cerr << "\nType 0 and press enter to continue : ";
-        int dummy_int = 0;
-        std::cin >> dummy_int;
-      }
-      GlobalMPISession::barrier();
+      parsePauseIfAsked(procRank, opt_name, pause_opt);
       continue;
     }
     // Lookup the option (we had better find it!)
@@ -566,6 +552,36 @@ void CommandLineProcessor::printHelpMessage( const char program_name[],
     }
     if(throwExceptions_)
       TEUCHOS_TEST_FOR_EXCEPTION( true, HelpPrinted, "Help message was printed" );
+  }
+}
+
+/**
+ * Helper to handle the --pause-for-debugging option.
+ */
+void CommandLineProcessor::parsePauseIfAsked(
+  int procRank,
+  const std::string& /*opt_name*/,
+  const std::string& pause_opt
+  ) const
+{
+  // The original code block for handling pause option.
+  if (procRank == 0) {
+    // Gather PIDs for all processes (non-Windows)
+#ifndef _WIN32
+    Array<int> pids;
+    pids.resize(GlobalMPISession::getNProc());
+    int rank_pid = getpid();
+    GlobalMPISession::allGather(rank_pid,pids());
+    if(procRank == 0)
+      for (int k=0; k<GlobalMPISession::getNProc(); k++)
+        std::cerr << "Rank " << k << " has PID " << pids[k] << std::endl;
+#endif
+    if(procRank == 0) {
+      std::cerr << "\nType 0 and press enter to continue : ";
+      int dummy_int = 0;
+      std::cin >> dummy_int;
+    }
+    GlobalMPISession::barrier();
   }
 }
 

--- a/packages/teuchos/core/src/Teuchos_CommandLineProcessor.hpp
+++ b/packages/teuchos/core/src/Teuchos_CommandLineProcessor.hpp
@@ -378,6 +378,20 @@ public:
     ,std::ostream   *errout = &std::cerr
     ) const;
 
+  /**
+   * @brief Helper function to pause execution when the pause option is
+   * specified. This function encapsulates the logic that was originally
+   * in the main parse loop for handling the `--pause-for-debugging`
+   * option.
+   *
+   * The function is public so that tests can exercise it directly.
+   */
+  void parsePauseIfAsked(
+    int procRank,
+    const std::string& opt_name,
+    const std::string& pause_opt
+    ) const;
+
   //@}
 
   //! @name Miscellaneous


### PR DESCRIPTION
This was generated from the host machine running:

```bash
docker exec -it codex-2025-09-07_13-05-17 \
  bash -c "source /home/runner/.bashrc \
    && cd /mounted_from_host/Trilinos \
    && codex exec -s workspace-write -c model_provider=llama-cpp-gpt-oss-20b --model=gpt-oss-20b \
      '$(/home/rabartl/PROJECTS/ascdor-ai-tools/prompts/refactoring/extract_function/generate-extract-func-prompt.py \
      --def-file packages/teuchos/core/src/Teuchos_CommandLineProcessor.cpp \
      --decl-file packages/teuchos/core/src/Teuchos_CommandLineProcessor.hpp \
      -p Teuchos::CommandLineProcessor::parse \
      -l 292-309 \
      -n parsePauseIfAsked \
      -b BUILDS/clang-19-simple \
      --obj-target packages/teuchos/core/src/CMakeFiles/teuchoscore.dir/Teuchos_CommandLineProcessor.cpp.o \
      --test-target packages/teuchos/core/test/CommandLineProcessor/TeuchosCore_CommandLineProcessor_test.exe \
      -t TeuchosCore_CommandLineProcessor_test_MPI_1)'"
```

This build and passed the Teuchos test suite.

Note that in this refactoring, gpt-oss-20b did not extract all of the lines of code requested.  Instead, it left the outer if-statement begin and end in place.

This is a different solution from what it did in prior runs.

But this is technically correct!
