### PR TITLE
Extract function parsePauseIfAsked using Codex + gpt-oss-20b - 2025-09-08b

### DIFF
--- a/packages/teuchos/core/src/Teuchos_CommandLineProcessor.cpp
+++ b/packages/teuchos/core/src/Teuchos_CommandLineProcessor.cpp
@@ -289,24 +289,7 @@ CommandLineProcessor::parse(
       }
       continue;
     }
-    if( opt_name == pause_opt ) {
-#ifndef _WIN32
-      Array<int> pids;
-      pids.resize(GlobalMPISession::getNProc());
-      int rank_pid = getpid();
-      GlobalMPISession::allGather(rank_pid,pids());
-      if(procRank == 0)
-        for (int k=0; k<GlobalMPISession::getNProc(); k++)
-          std::cerr << "Rank " << k << " has PID " << pids[k] << std::endl;
-#endif
-      if(procRank == 0) {
-        std::cerr << "\nType 0 and press enter to continue : ";
-        int dummy_int = 0;
-        std::cin >> dummy_int;
-      }
-      GlobalMPISession::barrier();
-      continue;
-    }
+    if(parsePauseIfAsked(opt_name, pause_opt, procRank, errout)) continue;
     // Lookup the option (we had better find it!)
     options_list_t::iterator  itr = options_list_.find(opt_name);
     if( itr == options_list_.end() ) {
@@ -400,6 +383,33 @@ CommandLineProcessor::parse(
   return PARSE_SUCCESSFUL;
 }
 
+// -----------------------------------------------------------------------------
+// Helper to handle the "pause-for-debugging" option.
+// -----------------------------------------------------------------------------
+bool CommandLineProcessor::parsePauseIfAsked(
+  const std::string &opt_name,
+  const std::string &pause_opt,
+  int procRank,
+  std::ostream *errout ) const
+{
+  if (opt_name != pause_opt) return false;
+  #ifndef _WIN32
+  Array<int> pids;
+  pids.resize(GlobalMPISession::getNProc());
+  int rank_pid = getpid();
+  GlobalMPISession::allGather(rank_pid, pids());
+  if (procRank == 0)
+    for (int k = 0; k < GlobalMPISession::getNProc(); k++)
+      std::cerr << "Rank " << k << " has PID " << pids[k] << std::endl;
+  #endif
+  if (procRank == 0) {
+    std::cerr << "\nType 0 and press enter to continue : ";
+    int dummy_int = 0;
+    std::cin >> dummy_int;
+  }
+  GlobalMPISession::barrier();
+  return true;
+}
 
 void CommandLineProcessor::printHelpMessage( const char program_name[],
   std::ostream &out ) const

--- a/packages/teuchos/core/src/Teuchos_CommandLineProcessor.hpp
+++ b/packages/teuchos/core/src/Teuchos_CommandLineProcessor.hpp
@@ -378,6 +378,20 @@ public:
     ,std::ostream   *errout = &std::cerr
     ) const;
 
+  /**
+   * @brief Handle the "pause-for-debugging" option.
+   *
+   * This function implements the logic that was previously in the
+   * body of {@code parse} when the option {@code pause_opt} was
+   * encountered.  It returns {@code true} if the pause behaviour was
+   * performed and the caller should continue to the next iteration of
+   * the argument loop.
+   */
+  bool parsePauseIfAsked( const std::string &opt_name,
+                          const std::string &pause_opt,
+                          int procRank,
+                          std::ostream *errout ) const;
+
   //@}
 
   //! @name Miscellaneous


### PR DESCRIPTION
This was performed from the host machine where the codex derived container named codex-2025-09-07_13-05-17 is running:

```
time docker exec -it codex-2025-09-07_13-05-17 \
  bash -c "source /home/runner/.bashrc \
    && cd /mounted_from_host/Trilinos \
    && codex exec -s workspace-write -c model_provider=llama-cpp-gpt-oss-20b --model=gpt-oss-20b \
      '$(/home/rabartl/PROJECTS/ascdor-ai-tools/prompts/refactoring/extract_function/generate-extract-func-prompt.py \
      --def-file packages/teuchos/core/src/Teuchos_CommandLineProcessor.cpp \
      --decl-file packages/teuchos/core/src/Teuchos_CommandLineProcessor.hpp \
      -p Teuchos::CommandLineProcessor::parse \
      -l 292-309 \
      -n parsePauseIfAsked \
      -b BUILDS/clang-19-simple \
      --obj-target packages/teuchos/core/src/CMakeFiles/teuchoscore.dir/Teuchos_CommandLineProcessor.cpp.o \
      --test-target packages/teuchos/core/test/CommandLineProcessor/TeuchosCore_CommandLineProcessor_test.exe \
      -t TeuchosCore_CommandLineProcessor_test_MPI_1)'"
```

It completed in 1m49.336s!

Note that this is the same refactoring it did in PR bartlettroscoe/MyTrilinos#12.
