### PR TITLE
Extract Function refactoring of Tpetra::CrsMatrix::transferAndFillComplete() with codex + gpt-oss-20b - 2025-09-09a

### DIFF
--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -3539,6 +3539,21 @@ public:
                              const Teuchos::RCP<const map_type>& domainMap = Teuchos::null,
                              const Teuchos::RCP<const map_type>& rangeMap = Teuchos::null,
                              const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null) const;
+    /// @brief Helper that extracts and returns parameters used by transferAndFillComplete.
+    struct TransferAndFillCompleteGetCallersParamsResult {
+      bool isMM;
+      bool reverseMode;
+      bool restrictComm;
+      int mm_optimization_core_count;
+      Teuchos::RCP<Teuchos::ParameterList> matrixparams;
+      bool overrideAllreduce;
+      bool useKokkosPath;
+    };
+    TransferAndFillCompleteGetCallersParamsResult
+    transferAndFillComplete_getCallersParamters(
+      const Teuchos::RCP<Teuchos::ParameterList>& params,
+      const ::Tpetra::Details::Transfer<LocalOrdinal, GlobalOrdinal, Node>& rowTransfer,
+      const Teuchos::RCP<const ::Tpetra::Details::Transfer<LocalOrdinal, GlobalOrdinal, Node>>& domainTransfer) const;
 
     /// \brief Common implementation detail of insertGlobalValues and
     ///   insertGlobalValuesFiltered.

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -7738,46 +7738,30 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     }
 
     //
-    // Get the caller's parameters
-    //
-    bool isMM = false; // optimize for matrix-matrix ops.
-    bool reverseMode = false; // Are we in reverse mode?
-    bool restrictComm = false; // Do we need to restrict the communicator?
+    // Extract parameters used throughout this function.
+    auto paramsResult = transferAndFillComplete_getCallersParamters(params, rowTransfer, domainTransfer);
+    bool isMM = paramsResult.isMM;
+    bool reverseMode = paramsResult.reverseMode;
+    bool restrictComm = paramsResult.restrictComm;
+    int mm_optimization_core_count = paramsResult.mm_optimization_core_count;
+    RCP<ParameterList> matrixparams = paramsResult.matrixparams;
+    bool overrideAllreduce = paramsResult.overrideAllreduce;
+    bool useKokkosPath = paramsResult.useKokkosPath;
 
-    int mm_optimization_core_count =
-      Behavior::TAFC_OptimizationCoreCount();
-    RCP<ParameterList> matrixparams; // parameters for the destination matrix
-    bool overrideAllreduce = false;
-    bool useKokkosPath = false;
-    if (! params.is_null ()) {
-      matrixparams = sublist (params, "CrsMatrix");
-      reverseMode = params->get ("Reverse Mode", reverseMode);
-      useKokkosPath = params->get ("TAFC: use kokkos path", useKokkosPath);
-      restrictComm = params->get ("Restrict Communicator", restrictComm);
-      auto & slist = params->sublist("matrixmatrix: kernel params",false);
-      isMM = slist.get("isMatrixMatrix_TransferAndFillComplete",false);
-      mm_optimization_core_count = slist.get("MM_TAFC_OptimizationCoreCount",mm_optimization_core_count);
-
-      overrideAllreduce = slist.get("MM_TAFC_OverrideAllreduceCheck",false);
-      if(getComm()->getSize() < mm_optimization_core_count && isMM)   isMM = false;
-      if(reverseMode) isMM = false;
-    }
-
-   // Only used in the sparse matrix-matrix multiply (isMM) case.
-   std::shared_ptr< ::Tpetra::Details::CommRequest> iallreduceRequest;
-   int mismatch = 0;
-   int reduced_mismatch = 0;
-   if (isMM && !overrideAllreduce) {
-
-     // Test for pathological matrix transfer
-     const bool source_vals = ! getGraph ()->getImporter ().is_null();
-     const bool target_vals = ! (rowTransfer.getExportLIDs ().size() == 0 ||
+    // Only used in the sparse matrix-matrix multiply (isMM) case.
+    std::shared_ptr< ::Tpetra::Details::CommRequest> iallreduceRequest;
+    int mismatch = 0;
+    int reduced_mismatch = 0;
+    if (isMM && !overrideAllreduce) {
+      // Test for pathological matrix transfer
+      const bool source_vals = ! getGraph ()->getImporter ().is_null();
+      const bool target_vals = ! (rowTransfer.getExportLIDs ().size() == 0 ||
                                  rowTransfer.getRemoteLIDs ().size() == 0);
-     mismatch = (source_vals != target_vals) ? 1 : 0;
-     iallreduceRequest =
-       ::Tpetra::Details::iallreduce (mismatch, reduced_mismatch,
-                                      Teuchos::REDUCE_MAX, * (getComm ()));
-   }
+      mismatch = (source_vals != target_vals) ? 1 : 0;
+      iallreduceRequest =
+        ::Tpetra::Details::iallreduce (mismatch, reduced_mismatch,
+                                       Teuchos::REDUCE_MAX, * (getComm ()));
+    }
 
 #ifdef HAVE_TPETRA_MMM_TIMINGS
     using Teuchos::TimeMonitor;
@@ -9135,6 +9119,41 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
       std::cerr << os.str ();
     }
   } //transferAndFillComplete
+// ---------------------------------------------------------------------------
+// Helper that extracts the parameters used by transferAndFillComplete.
+// ---------------------------------------------------------------------------
+template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+typename CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::TransferAndFillCompleteGetCallersParamsResult
+CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::transferAndFillComplete_getCallersParamters(
+  const Teuchos::RCP<Teuchos::ParameterList>& params,
+  const ::Tpetra::Details::Transfer<LocalOrdinal, GlobalOrdinal, Node>& rowTransfer,
+  const Teuchos::RCP<const ::Tpetra::Details::Transfer<LocalOrdinal, GlobalOrdinal, Node>>& domainTransfer) const
+{
+  // Note: parameters that depend only on params are computed here.
+  bool isMM = false;
+  bool reverseMode = false;
+  bool restrictComm = false;
+  int mm_optimization_core_count = Details::Behavior::TAFC_OptimizationCoreCount();
+  Teuchos::RCP<Teuchos::ParameterList> matrixparams = Teuchos::null;
+  bool overrideAllreduce = false;
+  bool useKokkosPath = false;
+  if (!params.is_null()) {
+    matrixparams = sublist(params, "CrsMatrix");
+    reverseMode = params->get("Reverse Mode", reverseMode);
+    useKokkosPath = params->get("TAFC: use kokkos path", useKokkosPath);
+    restrictComm = params->get("Restrict Communicator", restrictComm);
+    auto& slist = params->sublist("matrixmatrix: kernel params", false);
+    isMM = slist.get("isMatrixMatrix_TransferAndFillComplete", false);
+    mm_optimization_core_count = slist.get("MM_TAFC_OptimizationCoreCount", mm_optimization_core_count);
+    overrideAllreduce = slist.get("MM_TAFC_OverrideAllreduceCheck", false);
+    if (getComm()->getSize() < mm_optimization_core_count && isMM)
+      isMM = false;
+    if (reverseMode)
+      isMM = false;
+  }
+  return TransferAndFillCompleteGetCallersParamsResult{isMM, reverseMode, restrictComm,
+    mm_optimization_core_count, matrixparams, overrideAllreduce, useKokkosPath};
+}
 
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>


### PR DESCRIPTION
This was performed automatically using codex + gpt-oss-20b with 32k context window:

```
codex -a never -s workspace-write -c model_provider=llama-cpp-gpt-oss-20b-32k --model gpt-oss-20b-32k \
  "$(/mounted_from_host/ascdor-ai-tools/prompts/refactoring/extract_function/generate-extract-func-prompt.py \
  --def-file 'packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp' \
  --decl-file 'packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp' \
  -p 'Tpetra::CrsMatrix:transferAndFillComplete' \
  -l 7743-7780 \
  -n transferAndFillComplete_getCallersParamters \
  -b BUILDS/clang-19-simple \
  --obj-target packages/tpetra/core/src/CMakeFiles/tpetra.dir/Tpetra_CrsMatrix_DOUBLE_DOUBLE_INT_LONG_LONG_SERIAL.cpp.o \
  --test-target packages/tpetra/core/test/CrsMatrix/TpetraCore_CrsMatrix_UnitTests.exe \
  --test TpetraCore_CrsMatrix_UnitTests_MPI_4)"
```

The agent provided the summary:

  ### Key updates

  - Added a helper struct TransferAndFillCompleteGetCallersParamsResult and corresponding member function transferAndFillComplete_getCallersParamters in both declaration and definition files.
  - Replaced the original parameter‑parsing block in transferAndFillComplete with a single call to the new helper, preserving all logic and variable names.
  - Updated the header to declare the helper and its return struct.
  - Inserted the new function implementation after the original function’s closing brace in the definition file.

  ### Result

  - The refactor keeps the original behavior unchanged.
  - The new helper is public, testable, and can be reused by other components if needed.

This builds and passes the tests (without needing the forward decl for Tpetra::Details::CommRequest).
