### PR TITLE
Extract function parsePauseIfAsked using Codex + gpt-oss-20b - 2025-09-09

### DIFF
--- a/packages/teuchos/core/src/Teuchos_CommandLineProcessor.cpp
+++ b/packages/teuchos/core/src/Teuchos_CommandLineProcessor.cpp
@@ -289,22 +289,7 @@ CommandLineProcessor::parse(
       }
       continue;
     }
-    if( opt_name == pause_opt ) {
-#ifndef _WIN32
-      Array<int> pids;
-      pids.resize(GlobalMPISession::getNProc());
-      int rank_pid = getpid();
-      GlobalMPISession::allGather(rank_pid,pids());
-      if(procRank == 0)
-        for (int k=0; k<GlobalMPISession::getNProc(); k++)
-          std::cerr << "Rank " << k << " has PID " << pids[k] << std::endl;
-#endif
-      if(procRank == 0) {
-        std::cerr << "\nType 0 and press enter to continue : ";
-        int dummy_int = 0;
-        std::cin >> dummy_int;
-      }
-      GlobalMPISession::barrier();
+    if( parsePauseIfAsked(opt_name, pause_opt, procRank, errout) ) {
       continue;
     }
     // Lookup the option (we had better find it!)
@@ -398,6 +383,39 @@ CommandLineProcessor::parse(
     RCPNodeTracer::setPrintRCPNodeStatisticsOnExit(print_rcpnode_statistics_on_exit_);
   }
   return PARSE_SUCCESSFUL;
+}
+
+/**
+ * @brief Helper that implements the pause‑for‑debugging logic.
+ *
+ * Returns true if the pause option was detected and handled, false otherwise.
+ */
+bool CommandLineProcessor::parsePauseIfAsked(
+  const std::string &opt_name,
+  const std::string &pause_opt,
+  int procRank,
+  std::ostream *errout
+  ) const
+{
+  if( opt_name == pause_opt ) {
+#ifndef _WIN32
+    Array<int> pids;
+    pids.resize(GlobalMPISession::getNProc());
+    int rank_pid = getpid();
+    GlobalMPISession::allGather(rank_pid,pids());
+    if(procRank == 0)
+      for (int k=0; k<GlobalMPISession::getNProc(); k++)
+        std::cerr << "Rank " << k << " has PID " << pids[k] << std::endl;
+#endif
+    if(procRank == 0) {
+      std::cerr << "\nType 0 and press enter to continue : ";
+      int dummy_int = 0;
+      std::cin >> dummy_int;
+    }
+    GlobalMPISession::barrier();
+    return true;
+  }
+  return false;
 }
 
 

--- a/packages/teuchos/core/src/Teuchos_CommandLineProcessor.hpp
+++ b/packages/teuchos/core/src/Teuchos_CommandLineProcessor.hpp
@@ -378,6 +378,21 @@ public:
     ,std::ostream   *errout = &std::cerr
     ) const;
 
+  /**
+   * @brief Helper to pause execution if the pause option was specified.
+   *
+   * This function encapsulates the logic that previously lived directly in
+   * {@link parse}.  It returns true if the current iteration of the
+   * command‑line parsing loop should `continue` (i.e., skip the remaining
+   * option processing for the current argument).
+   */
+  bool parsePauseIfAsked(
+    const std::string &opt_name,
+    const std::string &pause_opt,
+    int procRank,
+    std::ostream *errout
+    ) const;
+
   //@}
 
   //! @name Miscellaneous


### PR DESCRIPTION
This was produced using:

```
codex --ask-for-approval never --sandbox workspace-write \
  -c model_provider=llama-cpp-gpt-oss-20b-32k --model=gpt-oss-20b \
  "$(/mounted_from_host/ascdor-ai-tools/prompts/refactoring/extract_function/generate-extract-func-prompt.py \
  --def-file 'packages/teuchos/core/src/Teuchos_CommandLineProcessor.cpp' \
  --decl-file 'packages/teuchos/core/src/Teuchos_CommandLineProcessor.hpp' \
  -p 'Teuchos::CommandLineProcessor::parse' \
  -l 292-309 \
  -n parsePauseIfAsked \
  -b BUILDS/clang-19-simple \
  --obj-target packages/teuchos/core/src/CMakeFiles/teuchoscore.dir/Teuchos_CommandLineProcessor.cpp.o \
  --test-target packages/teuchos/core/test/CommandLineProcessor/TeuchosCore_CommandLineProcessor_test.exe \
  --test TeuchosCore_CommandLineProcessor_test_MPI_1)"
```

This passed and built all of the tests.

NOTE: This time it used branches for `{ continue; }`, unlike PR bartlettroscoe/MyTrilinos#12.  So interesting how the model can produce different refactoring output each time, but all are still valid.
