### PR TITLE
Generate characterization tests for Teuchos::SerialSymDenseMatrix::normFrobenius() using codex + gpt-oss-20b - 2025-09-21c

### DIFF
--- a/packages/teuchos/numerics/test/DenseMatrix/SerialSymDenseMatrix_UnitTests.cpp
+++ b/packages/teuchos/numerics/test/DenseMatrix/SerialSymDenseMatrix_UnitTests.cpp
@@ -8,3 +8,37 @@ TEST(SerialDenseMatrixBasic, DummyConstruction) {
   A(0,0) = 1.25;
   EXPECT_DOUBLE_EQ(1.25, A(0,0));
 }
+
+// Characterization tests for normFrobenius
+TEST(SerialSymDenseMatrixNorm, ZeroMatrix) {
+  Teuchos::SerialSymDenseMatrix<int,double> A(3, true); // upper flag not relevant for zero
+  // No values set, remains zero
+  auto result = A.normFrobenius();
+  EXPECT_DOUBLE_EQ(0.0, result); // observed
+}
+
+TEST(SerialSymDenseMatrixNorm, OneByOne) {
+  Teuchos::SerialSymDenseMatrix<int,double> A(1);
+  A(0,0) = 3.0;
+  auto result = A.normFrobenius();
+  EXPECT_DOUBLE_EQ(3.0, result); // observed
+}
+
+TEST(SerialSymDenseMatrixNorm, TwoByTwoLower) {
+  Teuchos::SerialSymDenseMatrix<int,double> A(2);
+  A(0,0) = 1.0;
+  A(1,0) = 2.0; // lower off-diagonal
+  A(1,1) = 3.0;
+  auto result = A.normFrobenius();
+  EXPECT_DOUBLE_EQ(4.2426406871192848, result); // observed
+}
+
+TEST(SerialSymDenseMatrixNorm, TwoByTwoUpper) {
+  // Create upper matrix using constructor with upper flag
+  Teuchos::SerialSymDenseMatrix<int,double> A(2, true);
+  A(0,0) = 1.0;
+  A(0,1) = 4.0; // upper off-diagonal
+  A(1,1) = 5.0;
+  auto result = A.normFrobenius();
+  EXPECT_DOUBLE_EQ(7.6157731058639087, result); // observed
+}


### PR DESCRIPTION
This was created in one shot with codex-cli 0.39.0 and gpt-oss-20b with:

```bash
codex --ask-for-approval never --sandbox danger-full-access \
  -c model_provider=llama-cpp-gpt-oss-20b-largest-fit --model=openai/gpt-oss-20b \
  "$(generate-characterization-tests-prompt.py \
    -f normFrobenius \
    --decl-file packages/teuchos/numerics/src/Teuchos_SerialSymDenseMatrix.hpp \
    --def-file packages/teuchos/numerics/src/Teuchos_SerialSymDenseMatrix.hpp \
    -l 867 \
    --test-file packages/teuchos/numerics/test/DenseMatrix/SerialSymDenseMatrix_UnitTests.cpp \
    --build-dir BUILDS/clang-19-simple-cov \
    --obj-target packages/teuchos/numerics/test/DenseMatrix/CMakeFiles/TeuchosNumerics_SerialSymDenseMatrix_UnitTests.dir/SerialSymDenseMatrix_UnitTests.cpp.o \
    --test-target TeuchosNumerics_SerialSymDenseMatrix_UnitTests.exe \
    --test-name TeuchosNumerics_SerialSymDenseMatrix_UnitTests_MPI_1)"
```

This only produced coverage of:

```text
Name                                                              Regions    Miss   Cover     Lines    Miss   Cover  Branches    Miss   Cover
---------------------------------------------------------------------------------------------------------------------------------------------
Teuchos::SerialSymDenseMatrix<int, double>::normFrobenius() const      16       7  56.25%        23       7  69.57%        10       5  50.00%
---------------------------------------------------------------------------------------------------------------------------------------------
```

But at least it followed the LCCA process for generating characterization tests.
