### PR TITLE
Generate characterization tests for Teuchos::SerialSymDenseMatrix::normFrobenius() using codex + gpt-oss-120b - 2025-09-21d

### DIFF
--- a/packages/teuchos/numerics/test/DenseMatrix/SerialSymDenseMatrix_UnitTests.cpp
+++ b/packages/teuchos/numerics/test/DenseMatrix/SerialSymDenseMatrix_UnitTests.cpp
@@ -8,3 +8,32 @@ TEST(SerialDenseMatrixBasic, DummyConstruction) {
   A(0,0) = 1.25;
   EXPECT_DOUBLE_EQ(1.25, A(0,0));
 }
+
+// Characterization tests for normFrobenius (upper triangular storage)
+TEST(SerialSymDenseMatrixNormFrobenius, UpperTriangular) {
+  // Create a 2x2 symmetric matrix
+  Teuchos::SerialSymDenseMatrix<int,double> A(2);
+  // Use upper storage
+  A.setUpper();
+  // Fill matrix entries (symmetric)
+  A(0,0) = 1.0;
+  A(0,1) = 2.0; // off-diagonal
+  A(1,1) = 3.0;
+  double result = A.normFrobenius();
+  // Dummy expected value; will be replaced after observing actual output
+  EXPECT_DOUBLE_EQ(result, 4.2426406871192848);
+}
+
+// Characterization tests for normFrobenius (lower triangular storage)
+TEST(SerialSymDenseMatrixNormFrobenius, LowerTriangular) {
+  // Create a 2x2 symmetric matrix with default (lower) storage
+  Teuchos::SerialSymDenseMatrix<int,double> A(2);
+  // Ensure lower storage (default)
+  // Fill matrix entries (symmetric)
+  A(0,0) = 1.0;
+  A(0,1) = 2.0; // off-diagonal
+  A(1,1) = 3.0;
+  double result = A.normFrobenius();
+  // Dummy expected value; will be replaced after observing actual output
+  EXPECT_DOUBLE_EQ(result, 4.2426406871192848);
+}


### PR DESCRIPTION
This was created in one shot with codex-cli 0.39.0 and gpt-oss-120b with:

```bash
codex --ask-for-approval never --sandbox danger-full-access \
  -c model_provider=llama-cpp-gpt-oss-120b-full --model=openai/gpt-oss-120b \
  "$(generate-characterization-tests-prompt.py \
    -f normFrobenius \
    --decl-file packages/teuchos/numerics/src/Teuchos_SerialSymDenseMatrix.hpp \
    --def-file packages/teuchos/numerics/src/Teuchos_SerialSymDenseMatrix.hpp \
    -l 867 \
    --test-file packages/teuchos/numerics/test/DenseMatrix/SerialSymDenseMatrix_UnitTests.cpp \
    --build-dir BUILDS/clang-19-simple-cov \
    --obj-target packages/teuchos/numerics/test/DenseMatrix/CMakeFiles/TeuchosNumerics_SerialSymDenseMatrix_UnitTests.dir/SerialSymDenseMatrix_UnitTests.cpp.o \
    --test-target TeuchosNumerics_SerialSymDenseMatrix_UnitTests.exe \
    --test-name TeuchosNumerics_SerialSymDenseMatrix_UnitTests_MPI_1)"
```

This produced 100% region, statement, and branch coverage.

This followed the proper LCCA process of running the tests to get the expected values.
