### PR TITLE
Generate characterization tests for Teuchos::SerialSymDenseMatrix::normFrobenius() using codex + gpt-oss-120b - 2025--9-21e

### DIFF
--- a/packages/teuchos/numerics/test/DenseMatrix/SerialSymDenseMatrix_UnitTests.cpp
+++ b/packages/teuchos/numerics/test/DenseMatrix/SerialSymDenseMatrix_UnitTests.cpp
@@ -8,3 +8,32 @@ TEST(SerialDenseMatrixBasic, DummyConstruction) {
   A(0,0) = 1.25;
   EXPECT_DOUBLE_EQ(1.25, A(0,0));
 }
+
+// Characterization tests for normFrobenius()
+TEST(SerialSymDenseMatrixNormFrobenius, UpperTriangular) {
+  // Create a 2x2 matrix and set it as upper triangular
+  Teuchos::SerialSymDenseMatrix<int,double> A(2);
+  A.setUpper();
+  // Fill matrix entries (full matrix view)
+  A(0,0) = 1.0;
+  A(0,1) = 2.0;
+  A(1,1) = 3.0;
+  // Compute norm
+  double norm = A.normFrobenius();
+  // Dummy expected value; will be replaced after observing actual output
+  double expected = 4.2426406871192848;
+  EXPECT_DOUBLE_EQ(expected, norm);
+}
+
+TEST(SerialSymDenseMatrixNormFrobenius, LowerTriangular) {
+  // Create a 2x2 matrix (default lower triangular)
+  Teuchos::SerialSymDenseMatrix<int,double> A(2);
+  A.setLower();
+  // Fill matrix entries
+  A(0,0) = 1.0;
+  A(1,0) = 2.0; // lower off-diagonal element
+  A(1,1) = 3.0;
+  double norm = A.normFrobenius();
+  double expected = 4.2426406871192848;
+  EXPECT_DOUBLE_EQ(expected, norm);
+}


### PR DESCRIPTION

This was created in one shot with codex-cli 0.39.0 and gpt-oss-120b with:

```bash
alias generate-characterization-tests-prompt.py=/mounted_from_host/ascdor-ai-tools/prompts/testing/gen_character_tests/generate-characterization-tests-prompt.py \ && time codex exec --sandbox danger-full-access \
  -c model_provider=llama-cpp-gpt-oss-120b-full --model=openai/gpt-oss-120b \
  "$(generate-characterization-tests-prompt.py \
    -f normFrobenius \
    --decl-file packages/teuchos/numerics/src/Teuchos_SerialSymDenseMatrix.hpp \
    --def-file packages/teuchos/numerics/src/Teuchos_SerialSymDenseMatrix.hpp \
    -l 867 \
    --test-file packages/teuchos/numerics/test/DenseMatrix/SerialSymDenseMatrix_UnitTests.cpp \
    --build-dir BUILDS/clang-19-simple-cov \
    --obj-target packages/teuchos/numerics/test/DenseMatrix/CMakeFiles/TeuchosNumerics_SerialSymDenseMatrix_UnitTests.dir/SerialSymDenseMatrix_UnitTests.cpp.o \
    --test-target TeuchosNumerics_SerialSymDenseMatrix_UnitTests.exe \
    --test-name TeuchosNumerics_SerialSymDenseMatrix_UnitTests_MPI_1)"
```

This completed in:

```text
real    9m27.283s
user    0m4.073s
sys     0m2.149s
```
This produced 100% region, statement, and branch coverage.

This seems to have followed the proper LCCA process.
