### PR TITLE
Generate characterization tests for Teuchos::SerialSymDenseMatrix::normFrobenius() using codex + gpt-5-codex - 2025-09-21f

### DIFF
--- a/packages/teuchos/numerics/test/DenseMatrix/SerialSymDenseMatrix_UnitTests.cpp
+++ b/packages/teuchos/numerics/test/DenseMatrix/SerialSymDenseMatrix_UnitTests.cpp
@@ -8,3 +8,30 @@ TEST(SerialDenseMatrixBasic, DummyConstruction) {
   A(0,0) = 1.25;
   EXPECT_DOUBLE_EQ(1.25, A(0,0));
 }
+
+TEST(SerialSymDenseMatrixNormFrobenius, UsesLowerTriangleByDefault) {
+  Teuchos::SerialSymDenseMatrix<int,double> matrix(3, true);
+  matrix(0,0) = 1.0;
+  matrix(1,0) = -2.0;
+  matrix(1,1) = 3.0;
+  matrix(2,0) = 4.0;
+  matrix(2,1) = -5.0;
+  matrix(2,2) = 6.0;
+
+  const double result = matrix.normFrobenius();
+  EXPECT_DOUBLE_EQ(11.661903789690601, result);
+}
+
+TEST(SerialSymDenseMatrixNormFrobenius, HonorsUpperTriangleWhenSelected) {
+  Teuchos::SerialSymDenseMatrix<int,double> matrix(3, true);
+  matrix.setUpper();
+  matrix(0,0) = 1.5;
+  matrix(0,1) = -2.5;
+  matrix(0,2) = 3.5;
+  matrix(1,1) = -4.5;
+  matrix(1,2) = 5.5;
+  matrix(2,2) = -6.5;
+
+  const double result = matrix.normFrobenius();
+  EXPECT_DOUBLE_EQ(12.737739202856996, result);
+}


### PR DESCRIPTION
This was created in one shot with codex-cli 0.39.0 and gpt-5-codex medium with:

```bash
codex exec --sandbox danger-full-access \
  --model=gpt-5-codex -c model_reasoning_effort=medium \
  "$(generate-characterization-tests-prompt.py \
    -f normFrobenius \
    --decl-file packages/teuchos/numerics/src/Teuchos_SerialSymDenseMatrix.hpp \
    --def-file packages/teuchos/numerics/src/Teuchos_SerialSymDenseMatrix.hpp \
    -l 867 \
    --test-file packages/teuchos/numerics/test/DenseMatrix/SerialSymDenseMatrix_UnitTests.cpp \
    --build-dir BUILDS/clang-19-simple-cov \
    --obj-target packages/teuchos/numerics/test/DenseMatrix/CMakeFiles/TeuchosNumerics_SerialSymDenseMatrix_UnitTests.dir/SerialSymDenseMatrix_UnitTests.cpp.o \
    --test-target TeuchosNumerics_SerialSymDenseMatrix_UnitTests.exe \
    --test-name TeuchosNumerics_SerialSymDenseMatrix_UnitTests_MPI_1)"
```

This completed in:

```text
real    2m23.799s
user    0m2.528s
sys     0m1.163s
```

That gave full coverage.

That looked to follow the LCCA process getting the expected values from running the tests.
