### PR TITLE
Generate characterization tests for Teuchos::SerialSymDenseMatrix::normFrobenius() using codex + gpt-oss-20b high - 2025-09-23b

### DIFF
--- a/packages/teuchos/numerics/test/DenseMatrix/SerialSymDenseMatrix_UnitTests.cpp
+++ b/packages/teuchos/numerics/test/DenseMatrix/SerialSymDenseMatrix_UnitTests.cpp
@@ -8,3 +8,40 @@ TEST(SerialDenseMatrixBasic, DummyConstruction) {
   A(0,0) = 1.25;
   EXPECT_DOUBLE_EQ(1.25, A(0,0));
 }
+// Test cases for normFrobenius
+
+// Helper function to create a 2x2 matrix with known values
+Teuchos::SerialSymDenseMatrix<int,double> createMatrix2x2Upper() {
+  Teuchos::SerialSymDenseMatrix<int,double> M(2);
+  // By default, active part is lower triangular; set upper
+  M.setUpper();
+  // Set values (upper triangular stored only)
+  M(0,0) = 1.0;
+  M(0,1) = 2.0; // off-diagonal
+  M(1,1) = 3.0;
+  return M;
+}
+
+Teuchos::SerialSymDenseMatrix<int,double> createMatrix2x2Lower() {
+  Teuchos::SerialSymDenseMatrix<int,double> M(2);
+  // default lower active
+  M(0,0) = 1.0;
+  M(1,0) = 2.0; // off-diagonal stored in lower part
+  M(1,1) = 3.0;
+  return M;
+}
+
+TEST(SerialSymDenseMatrixNorm, Upper2x2) {
+  auto M = createMatrix2x2Upper();
+  double result = M.normFrobenius();
+  // Expected norm: sqrt(1^2 + 2^2 + 2^2 + 3^2) = sqrt(18)
+  double expected = 4.242640687119285; // sqrt(18)
+  EXPECT_DOUBLE_EQ(result, expected);
+}
+
+TEST(SerialSymDenseMatrixNorm, Lower2x2) {
+  auto M = createMatrix2x2Lower();
+  double result = M.normFrobenius();
+  double expected = 4.242640687119285; // sqrt(18)
+  EXPECT_DOUBLE_EQ(result, expected);
+}


### PR DESCRIPTION
This was created in one shot with codex-cli 0.39.0 and gpt-oss-20b high with:

```bash
codex --ask-for-approval never --sandbox danger-full-access \
  -c model_provider=llama-cpp-gpt-oss-20b-largest-fit \
  --model=openai/gpt-oss-20b \
  "$(generate-characterization-tests-prompt.py \
    -f normFrobenius \
    --decl-file packages/teuchos/numerics/src/Teuchos_SerialSymDenseMatrix.hpp \
    --def-file packages/teuchos/numerics/src/Teuchos_SerialSymDenseMatrix.hpp \
    -l 867 \
    --test-file packages/teuchos/numerics/test/DenseMatrix/SerialSymDenseMatrix_UnitTests.cpp \
    --build-dir BUILDS/clang-19-simple-cov \
    --obj-target packages/teuchos/numerics/test/DenseMatrix/CMakeFiles/TeuchosNumerics_SerialSymDenseMatrix_UnitTests.dir/SerialSymDenseMatrix_UnitTests.cpp.o \
    --test-target TeuchosNumerics_SerialSymDenseMatrix_UnitTests.exe \
    --test-name TeuchosNumerics_SerialSymDenseMatrix_UnitTests_MPI_1)"
```

llama-server was started with:

```bash
~/PROJECTS/rabai25_setup/llama.cpp/llama-server-gpt-oss-20b-ctx-largest-fit.sh \
  --chat-template-kwargs '{"reasoning_effort": "high"}'
```

This finished in less than 2 minutes and achieved 100% coverage.

Very nice.
