### PR TITLE
Tpetra::CrsMatrix::transferAndFillComplete_getCallersParameters() Extract Function codex + gtp-5-codex medium 2025-10-21

### DIFF
--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -35,6 +35,10 @@ namespace Tpetra {
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 class crsMatrix_Swap_Tester;
 
+namespace Details {
+class CommRequest;
+}  // namespace Details
+
 /// \brief Nonmember CrsMatrix constructor that fuses Import and fillComplete().
 /// \relatesalso CrsMatrix
 /// \tparam CrsMatrixType A specialization of CrsMatrix.
@@ -3500,6 +3504,23 @@ class CrsMatrix : public RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>,
                           const Teuchos::RCP<const map_type>& domainMap      = Teuchos::null,
                           const Teuchos::RCP<const map_type>& rangeMap       = Teuchos::null,
                           const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null) const;
+
+ public:
+  void
+  transferAndFillComplete_getCallersParameters(
+      bool& isMM,
+      bool& reverseMode,
+      bool& restrictComm,
+      Teuchos::RCP<Teuchos::ParameterList>& matrixparams,
+      bool& overrideAllreduce,
+      bool& useKokkosPath,
+      std::shared_ptr<::Tpetra::Details::CommRequest>& iallreduceRequest,
+      int& mismatch,
+      int& reduced_mismatch,
+      const ::Tpetra::Details::Transfer<LocalOrdinal, GlobalOrdinal, Node>& rowTransfer,
+      const Teuchos::RCP<Teuchos::ParameterList>& params) const;
+
+ private:
 
   /// \brief Common implementation detail of insertGlobalValues and
   ///   insertGlobalValuesFiltered.

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -7360,46 +7360,23 @@ void CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     std::cerr << os.str();
   }
 
+  bool isMM;         // optimize for matrix-matrix ops.
+  bool reverseMode;  // Are we in reverse mode?
+  bool restrictComm; // Do we need to restrict the communicator?
+  RCP<ParameterList> matrixparams;  // parameters for the destination matrix
+  bool overrideAllreduce;
+  bool useKokkosPath;
+  std::shared_ptr<::Tpetra::Details::CommRequest> iallreduceRequest;
+  int mismatch;
+  int reduced_mismatch;
+
   //
   // Get the caller's parameters
   //
-  bool isMM         = false;  // optimize for matrix-matrix ops.
-  bool reverseMode  = false;  // Are we in reverse mode?
-  bool restrictComm = false;  // Do we need to restrict the communicator?
-
-  int mm_optimization_core_count =
-      Behavior::TAFC_OptimizationCoreCount();
-  RCP<ParameterList> matrixparams;  // parameters for the destination matrix
-  bool overrideAllreduce = false;
-  bool useKokkosPath     = false;
-  if (!params.is_null()) {
-    matrixparams               = sublist(params, "CrsMatrix");
-    reverseMode                = params->get("Reverse Mode", reverseMode);
-    useKokkosPath              = params->get("TAFC: use kokkos path", useKokkosPath);
-    restrictComm               = params->get("Restrict Communicator", restrictComm);
-    auto& slist                = params->sublist("matrixmatrix: kernel params", false);
-    isMM                       = slist.get("isMatrixMatrix_TransferAndFillComplete", false);
-    mm_optimization_core_count = slist.get("MM_TAFC_OptimizationCoreCount", mm_optimization_core_count);
-
-    overrideAllreduce = slist.get("MM_TAFC_OverrideAllreduceCheck", false);
-    if (getComm()->getSize() < mm_optimization_core_count && isMM) isMM = false;
-    if (reverseMode) isMM = false;
-  }
-
-  // Only used in the sparse matrix-matrix multiply (isMM) case.
-  std::shared_ptr<::Tpetra::Details::CommRequest> iallreduceRequest;
-  int mismatch         = 0;
-  int reduced_mismatch = 0;
-  if (isMM && !overrideAllreduce) {
-    // Test for pathological matrix transfer
-    const bool source_vals = !getGraph()->getImporter().is_null();
-    const bool target_vals = !(rowTransfer.getExportLIDs().size() == 0 ||
-                               rowTransfer.getRemoteLIDs().size() == 0);
-    mismatch               = (source_vals != target_vals) ? 1 : 0;
-    iallreduceRequest =
-        ::Tpetra::Details::iallreduce(mismatch, reduced_mismatch,
-                                      Teuchos::REDUCE_MAX, *(getComm()));
-  }
+  transferAndFillComplete_getCallersParameters(
+      isMM, reverseMode, restrictComm, matrixparams, overrideAllreduce,
+      useKokkosPath, iallreduceRequest, mismatch, reduced_mismatch,
+      rowTransfer, params);
 
 #ifdef HAVE_TPETRA_MMM_TIMINGS
   using Teuchos::TimeMonitor;
@@ -8721,6 +8698,59 @@ void CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     std::cerr << os.str();
   }
 }  // transferAndFillComplete
+
+template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+void CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
+    transferAndFillComplete_getCallersParameters(
+        bool& isMM,
+        bool& reverseMode,
+        bool& restrictComm,
+        Teuchos::RCP<Teuchos::ParameterList>& matrixparams,
+        bool& overrideAllreduce,
+        bool& useKokkosPath,
+        std::shared_ptr<::Tpetra::Details::CommRequest>& iallreduceRequest,
+        int& mismatch,
+        int& reduced_mismatch,
+        const ::Tpetra::Details::Transfer<LocalOrdinal, GlobalOrdinal, Node>& rowTransfer,
+        const Teuchos::RCP<Teuchos::ParameterList>& params) const {
+  isMM         = false;
+  reverseMode  = false;
+  restrictComm = false;
+  matrixparams = Teuchos::null;
+  overrideAllreduce = false;
+  useKokkosPath     = false;
+  iallreduceRequest.reset();
+  mismatch         = 0;
+  reduced_mismatch = 0;
+
+  int mm_optimization_core_count =
+      ::Tpetra::Details::Behavior::TAFC_OptimizationCoreCount();
+  if (!params.is_null()) {
+    matrixparams               = Teuchos::sublist(params, "CrsMatrix");
+    reverseMode                = params->get("Reverse Mode", reverseMode);
+    useKokkosPath              = params->get("TAFC: use kokkos path", useKokkosPath);
+    restrictComm               = params->get("Restrict Communicator", restrictComm);
+    auto& slist                = params->sublist("matrixmatrix: kernel params", false);
+    isMM                       = slist.get("isMatrixMatrix_TransferAndFillComplete", false);
+    mm_optimization_core_count = slist.get("MM_TAFC_OptimizationCoreCount", mm_optimization_core_count);
+
+    overrideAllreduce = slist.get("MM_TAFC_OverrideAllreduceCheck", false);
+    if (getComm()->getSize() < mm_optimization_core_count && isMM) isMM = false;
+    if (reverseMode) isMM = false;
+  }
+
+  // Only used in the sparse matrix-matrix multiply (isMM) case.
+  if (isMM && !overrideAllreduce) {
+    // Test for pathological matrix transfer
+    const bool source_vals = !getGraph()->getImporter().is_null();
+    const bool target_vals = !(rowTransfer.getExportLIDs().size() == 0 ||
+                               rowTransfer.getRemoteLIDs().size() == 0);
+    mismatch = (source_vals != target_vals) ? 1 : 0;
+    iallreduceRequest =
+        ::Tpetra::Details::iallreduce(mismatch, reduced_mismatch,
+                                      Teuchos::REDUCE_MAX, *(getComm()));
+  }
+}
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::


### PR DESCRIPTION
This was done 100% automatically by codex cli + gpt-5-codex medium.

The call to codex was:

```bash
codex -a never -s danger-full-access \
  --model=gpt-5-codex \
  "$(/mounted_from_host/ascdor-ai-tools/prompts/refactoring/extract_function/generate-extract-func-prompt.py \
  --def-file 'packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp' \
  --decl-file 'packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp' \
  -p 'Tpetra::CrsMatrix:transferAndFillComplete' \
  -l 7366-7402 \
  -n transferAndFillComplete_getCallersParameters \
  -b BUILDS/clang-19-simple-cov \
  --obj-target packages/tpetra/core/src/CMakeFiles/tpetra.dir/Tpetra_CrsMatrix_DOUBLE_DOUBLE_INT_LONG_LONG_SERIAL.cpp.o \
  --test-target packages/tpetra/core/test/CrsMatrix/TpetraCore_CrsMatrix_UnitTests.exe \
  --test TpetraCore_CrsMatrix_UnitTests_MPI_4)"
```

This took about 13m for this to complete.
