### PR TITLE
Tpetra::CrsMatrix::transferAndFillComplete_getCallersParameters() Extract Function codex + gpt-oss-20b high 2025-10-21

### DIFF
--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -29,6 +29,9 @@
 
 #include <memory>  // std::shared_ptr
 
+// Forward declaration of Tpetra::Details::CommRequest used in the helper
+namespace Tpetra { namespace Details { class CommRequest; } }
+
 namespace Tpetra {
 
 // Forward declaration for CrsMatrix::swap() test
@@ -3500,6 +3503,26 @@ class CrsMatrix : public RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>,
                           const Teuchos::RCP<const map_type>& domainMap      = Teuchos::null,
                           const Teuchos::RCP<const map_type>& rangeMap       = Teuchos::null,
                           const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null) const;
+
+  /// \brief Helper to extract caller parameters used in transferAndFillComplete.
+  ///
+  /// This function extracts the logic that previously lived inside
+  /// CrsMatrix::transferAndFillComplete.  It is public so that unit
+  /// tests can exercise the logic in isolation.
+  void
+    transferAndFillComplete_getCallersParameters(
+      const Teuchos::RCP<Teuchos::ParameterList>& params,
+      const ::Tpetra::Details::Transfer<LocalOrdinal, GlobalOrdinal, Node>& rowTransfer,
+      bool& isMM,
+      bool& reverseMode,
+      bool& restrictComm,
+      int& mm_optimization_core_count,
+      Teuchos::RCP<Teuchos::ParameterList>& matrixparams,
+      bool& overrideAllreduce,
+      bool& useKokkosPath,
+      std::shared_ptr<::Tpetra::Details::CommRequest>& iallreduceRequest,
+      int& mismatch,
+      int& reduced_mismatch) const;
 
   /// \brief Common implementation detail of insertGlobalValues and
   ///   insertGlobalValuesFiltered.

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -7321,6 +7321,54 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   return rcp_implicit_cast<row_matrix_type>(C);
 }
 
+// Definition of the helper function that extracts the caller parameters
+// used by transferAndFillComplete.  This function is public so that unit
+// tests can exercise the logic in isolation.
+template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+void CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
+    transferAndFillComplete_getCallersParameters(
+      const Teuchos::RCP<Teuchos::ParameterList>& params,
+      const ::Tpetra::Details::Transfer<LocalOrdinal, GlobalOrdinal, Node>& rowTransfer,
+      bool& isMM,
+      bool& reverseMode,
+      bool& restrictComm,
+      int& mm_optimization_core_count,
+      Teuchos::RCP<Teuchos::ParameterList>& matrixparams,
+      bool& overrideAllreduce,
+      bool& useKokkosPath,
+      std::shared_ptr<::Tpetra::Details::CommRequest>& iallreduceRequest,
+      int& mismatch,
+      int& reduced_mismatch) const
+{
+  using Teuchos::sublist;
+  // Initialize local variables (already declared by caller, but we set them
+  // here to ensure the correct values are passed back).
+  if (!params.is_null()) {
+    matrixparams = sublist(params, "CrsMatrix");
+    reverseMode = params->get("Reverse Mode", reverseMode);
+    useKokkosPath = params->get("TAFC: use kokkos path", useKokkosPath);
+    restrictComm = params->get("Restrict Communicator", restrictComm);
+    auto& slist = params->sublist("matrixmatrix: kernel params", false);
+    isMM = slist.get("isMatrixMatrix_TransferAndFillComplete", false);
+    mm_optimization_core_count = slist.get("MM_TAFC_OptimizationCoreCount", mm_optimization_core_count);
+    overrideAllreduce = slist.get("MM_TAFC_OverrideAllreduceCheck", false);
+    if (getComm()->getSize() < mm_optimization_core_count && isMM)
+      isMM = false;
+    if (reverseMode)
+      isMM = false;
+  }
+
+  if (isMM && !overrideAllreduce) {
+    const bool source_vals = !getGraph()->getImporter().is_null();
+    const bool target_vals = !(rowTransfer.getExportLIDs().size() == 0 ||
+                              rowTransfer.getRemoteLIDs().size() == 0);
+    mismatch = (source_vals != target_vals) ? 1 : 0;
+    iallreduceRequest =
+        ::Tpetra::Details::iallreduce(mismatch, reduced_mismatch,
+                                      Teuchos::REDUCE_MAX, *(getComm()));
+  }
+}
+
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     transferAndFillComplete(Teuchos::RCP<CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>>& destMat,
@@ -7363,43 +7411,22 @@ void CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   //
   // Get the caller's parameters
   //
-  bool isMM         = false;  // optimize for matrix-matrix ops.
-  bool reverseMode  = false;  // Are we in reverse mode?
+  // Get the caller's parameters
+  bool isMM = false;  // optimize for matrix-matrix ops.
+  bool reverseMode = false;  // Are we in reverse mode?
   bool restrictComm = false;  // Do we need to restrict the communicator?
-
-  int mm_optimization_core_count =
-      Behavior::TAFC_OptimizationCoreCount();
+  int mm_optimization_core_count = Behavior::TAFC_OptimizationCoreCount();
   RCP<ParameterList> matrixparams;  // parameters for the destination matrix
   bool overrideAllreduce = false;
-  bool useKokkosPath     = false;
-  if (!params.is_null()) {
-    matrixparams               = sublist(params, "CrsMatrix");
-    reverseMode                = params->get("Reverse Mode", reverseMode);
-    useKokkosPath              = params->get("TAFC: use kokkos path", useKokkosPath);
-    restrictComm               = params->get("Restrict Communicator", restrictComm);
-    auto& slist                = params->sublist("matrixmatrix: kernel params", false);
-    isMM                       = slist.get("isMatrixMatrix_TransferAndFillComplete", false);
-    mm_optimization_core_count = slist.get("MM_TAFC_OptimizationCoreCount", mm_optimization_core_count);
-
-    overrideAllreduce = slist.get("MM_TAFC_OverrideAllreduceCheck", false);
-    if (getComm()->getSize() < mm_optimization_core_count && isMM) isMM = false;
-    if (reverseMode) isMM = false;
-  }
-
-  // Only used in the sparse matrix-matrix multiply (isMM) case.
+  bool useKokkosPath = false;
   std::shared_ptr<::Tpetra::Details::CommRequest> iallreduceRequest;
-  int mismatch         = 0;
+  int mismatch = 0;
   int reduced_mismatch = 0;
-  if (isMM && !overrideAllreduce) {
-    // Test for pathological matrix transfer
-    const bool source_vals = !getGraph()->getImporter().is_null();
-    const bool target_vals = !(rowTransfer.getExportLIDs().size() == 0 ||
-                               rowTransfer.getRemoteLIDs().size() == 0);
-    mismatch               = (source_vals != target_vals) ? 1 : 0;
-    iallreduceRequest =
-        ::Tpetra::Details::iallreduce(mismatch, reduced_mismatch,
-                                      Teuchos::REDUCE_MAX, *(getComm()));
-  }
+  transferAndFillComplete_getCallersParameters(params, rowTransfer,
+      isMM, reverseMode, restrictComm,
+      mm_optimization_core_count,
+      matrixparams, overrideAllreduce, useKokkosPath,
+      iallreduceRequest, mismatch, reduced_mismatch);
 
 #ifdef HAVE_TPETRA_MMM_TIMINGS
   using Teuchos::TimeMonitor;


### PR DESCRIPTION
This was done 100% automatically by codex cli + gpt-oss-20b high.

The call to codex was:

```bash
codex -a never -s danger-full-access \
  -c model_provider=oss --model=openai/gpt-oss-20b-high \
  "$(/mounted_from_host/ascdor-ai-tools/prompts/refactoring/extract_function/generate-extract-func-prompt.py \
  --def-file 'packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp' \
  --decl-file 'packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp' \
  -p 'Tpetra::CrsMatrix:transferAndFillComplete' \
  -l 7366-7402 \
  -n transferAndFillComplete_getCallersParameters \
  -b BUILDS/clang-19-simple-cov \
  --obj-target packages/tpetra/core/src/CMakeFiles/tpetra.dir/Tpetra_CrsMatrix_DOUBLE_DOUBLE_INT_LONG_LONG_SERIAL.cpp.o \
  --test-target packages/tpetra/core/test/CrsMatrix/TpetraCore_CrsMatrix_UnitTests.exe \
  --test TpetraCore_CrsMatrix_UnitTests_MPI_4)"
```

This took about 25m for this to complete.
