### PR TITLE
Tpetra::CrsMatrix::transferAndFillComplete_getCallersParameters() Extract Function codex + gpt-oss-120b medium 2025-10-22

### DIFF
--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -14,6 +14,7 @@
 /// \brief Declaration of the Tpetra::CrsMatrix class
 
 #include "Tpetra_CrsMatrix_fwd.hpp"
+#include "Tpetra_Details_iallreduce.hpp"
 #include "TpetraExt_MatrixMatrix_fwd.hpp"
 #include "KokkosSparse_Utils.hpp"
 #include "KokkosSparse_CrsMatrix.hpp"
@@ -28,6 +29,10 @@
 #include "Teuchos_DataAccess.hpp"
 
 #include <memory>  // std::shared_ptr
+#include "Teuchos_Comm.hpp"
+
+// Forward declaration of CommRequest used in TransferAndFillCompleteParams
+namespace Tpetra { namespace Details { class CommRequest; } }
 
 namespace Tpetra {
 
@@ -3500,6 +3505,24 @@ class CrsMatrix : public RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>,
                           const Teuchos::RCP<const map_type>& domainMap      = Teuchos::null,
                           const Teuchos::RCP<const map_type>& rangeMap       = Teuchos::null,
                           const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null) const;
+
+  // New public helper to extract caller parameters for transferAndFillComplete
+  struct TransferAndFillCompleteParams {
+    bool isMM;
+    bool reverseMode;
+    bool restrictComm;
+    int mm_optimization_core_count;
+    Teuchos::RCP<Teuchos::ParameterList> matrixparams;
+    bool overrideAllreduce;
+    bool useKokkosPath;
+    std::shared_ptr<Tpetra::Details::CommRequest> iallreduceRequest;
+    int mismatch;
+    int reduced_mismatch;
+  };
+
+  TransferAndFillCompleteParams
+  transferAndFillComplete_getCallersParameters(const Teuchos::RCP<Teuchos::ParameterList>& params,
+      const ::Tpetra::Details::Transfer<LocalOrdinal, GlobalOrdinal, Node>& rowTransfer) const;
 
   /// \brief Common implementation detail of insertGlobalValues and
   ///   insertGlobalValuesFiltered.

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -7363,43 +7363,20 @@ void CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   //
   // Get the caller's parameters
   //
-  bool isMM         = false;  // optimize for matrix-matrix ops.
-  bool reverseMode  = false;  // Are we in reverse mode?
-  bool restrictComm = false;  // Do we need to restrict the communicator?
-
-  int mm_optimization_core_count =
-      Behavior::TAFC_OptimizationCoreCount();
-  RCP<ParameterList> matrixparams;  // parameters for the destination matrix
-  bool overrideAllreduce = false;
-  bool useKokkosPath     = false;
-  if (!params.is_null()) {
-    matrixparams               = sublist(params, "CrsMatrix");
-    reverseMode                = params->get("Reverse Mode", reverseMode);
-    useKokkosPath              = params->get("TAFC: use kokkos path", useKokkosPath);
-    restrictComm               = params->get("Restrict Communicator", restrictComm);
-    auto& slist                = params->sublist("matrixmatrix: kernel params", false);
-    isMM                       = slist.get("isMatrixMatrix_TransferAndFillComplete", false);
-    mm_optimization_core_count = slist.get("MM_TAFC_OptimizationCoreCount", mm_optimization_core_count);
-
-    overrideAllreduce = slist.get("MM_TAFC_OverrideAllreduceCheck", false);
-    if (getComm()->getSize() < mm_optimization_core_count && isMM) isMM = false;
-    if (reverseMode) isMM = false;
-  }
-
-  // Only used in the sparse matrix-matrix multiply (isMM) case.
-  std::shared_ptr<::Tpetra::Details::CommRequest> iallreduceRequest;
-  int mismatch         = 0;
-  int reduced_mismatch = 0;
-  if (isMM && !overrideAllreduce) {
-    // Test for pathological matrix transfer
-    const bool source_vals = !getGraph()->getImporter().is_null();
-    const bool target_vals = !(rowTransfer.getExportLIDs().size() == 0 ||
-                               rowTransfer.getRemoteLIDs().size() == 0);
-    mismatch               = (source_vals != target_vals) ? 1 : 0;
-    iallreduceRequest =
-        ::Tpetra::Details::iallreduce(mismatch, reduced_mismatch,
-                                      Teuchos::REDUCE_MAX, *(getComm()));
-  }
+  // Extract caller's parameters via helper
+  TransferAndFillCompleteParams callersParams =
+      this->transferAndFillComplete_getCallersParameters(params, rowTransfer);
+  bool isMM = callersParams.isMM;
+  bool reverseMode = callersParams.reverseMode;
+  bool restrictComm = callersParams.restrictComm;
+  int mm_optimization_core_count = callersParams.mm_optimization_core_count;
+  RCP<ParameterList> matrixparams = callersParams.matrixparams;
+  bool overrideAllreduce = callersParams.overrideAllreduce;
+  bool useKokkosPath = callersParams.useKokkosPath;
+  std::shared_ptr<::Tpetra::Details::CommRequest> iallreduceRequest =
+      callersParams.iallreduceRequest;
+  int mismatch = callersParams.mismatch;
+  int reduced_mismatch = callersParams.reduced_mismatch;
 
 #ifdef HAVE_TPETRA_MMM_TIMINGS
   using Teuchos::TimeMonitor;
@@ -8721,6 +8698,50 @@ void CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     std::cerr << os.str();
   }
 }  // transferAndFillComplete
+
+// Definition of helper to extract caller parameters
+template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+typename CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::TransferAndFillCompleteParams
+CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
+transferAndFillComplete_getCallersParameters(
+    const Teuchos::RCP<Teuchos::ParameterList>& params,
+    const ::Tpetra::Details::Transfer<LocalOrdinal, GlobalOrdinal, Node>& rowTransfer) const {
+  TransferAndFillCompleteParams p;
+  // Initialize defaults (matching original code)
+  p.isMM = false; // optimize for matrix-matrix ops.
+  p.reverseMode = false; // Are we in reverse mode?
+  p.restrictComm = false; // Do we need to restrict the communicator?
+  p.mm_optimization_core_count = Details::Behavior::TAFC_OptimizationCoreCount();
+  p.matrixparams = Teuchos::null;
+  p.overrideAllreduce = false;
+  p.useKokkosPath = false;
+  if (!params.is_null()) {
+    p.matrixparams = sublist(params, "CrsMatrix");
+    p.reverseMode = params->get("Reverse Mode", p.reverseMode);
+    p.useKokkosPath = params->get("TAFC: use kokkos path", p.useKokkosPath);
+    p.restrictComm = params->get("Restrict Communicator", p.restrictComm);
+    auto& slist = params->sublist("matrixmatrix: kernel params", false);
+    p.isMM = slist.get("isMatrixMatrix_TransferAndFillComplete", false);
+    p.mm_optimization_core_count = slist.get("MM_TAFC_OptimizationCoreCount", p.mm_optimization_core_count);
+    p.overrideAllreduce = slist.get("MM_TAFC_OverrideAllreduceCheck", false);
+    if (getComm()->getSize() < p.mm_optimization_core_count && p.isMM) p.isMM = false;
+    if (p.reverseMode) p.isMM = false;
+  }
+
+  // Only used in the sparse matrix-matrix multiply (isMM) case.
+  p.iallreduceRequest.reset();
+  p.mismatch = 0;
+  p.reduced_mismatch = 0;
+  if (p.isMM && !p.overrideAllreduce) {
+    const bool source_vals = !getGraph()->getImporter().is_null();
+    const bool target_vals = !(rowTransfer.getExportLIDs().size() == 0 ||
+                               rowTransfer.getRemoteLIDs().size() == 0);
+    p.mismatch = (source_vals != target_vals) ? 1 : 0;
+  p.iallreduceRequest = ::Tpetra::Details::iallreduce(p.mismatch, p.reduced_mismatch,
+                                 Teuchos::REDUCE_MAX, *(getComm()));
+  }
+  return p;
+}
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::


### PR DESCRIPTION
This was done 100% automatically by codex cli + gpt-oss-120b medium.

The call to codex was:

```bash
codex -a never -s danger-full-access \
  -c model_provider=oss --model=openai/gpt-oss-120b-medium-3 \
  "$(/mounted_from_host/ascdor-ai-tools/prompts/refactoring/extract_function/generate-extract-func-prompt.py \
  --def-file 'packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp' \
  --decl-file 'packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp' \
  -p 'Tpetra::CrsMatrix:transferAndFillComplete' \
  -l 7366-7402 \
  -n transferAndFillComplete_getCallersParameters \
  -b BUILDS/clang-19-simple-cov \
  --obj-target packages/tpetra/core/src/CMakeFiles/tpetra.dir/Tpetra_CrsMatrix_DOUBLE_DOUBLE_INT_LONG_LONG_SERIAL.cpp.o \
  --test-target packages/tpetra/core/test/CrsMatrix/TpetraCore_CrsMatrix_UnitTests.exe \
  --test TpetraCore_CrsMatrix_UnitTests_MPI_4)"
```

This took the agent about 15m to complete this.
