### PR TITLE
Squash remaining mull mutations: Generate characterization tests for Teuchos::SerialSymDenseMatrix::normFrobenius() using codex + gpt-oss-20b high - 2025-09-23b (#30)

### DIFF
--- a/packages/teuchos/numerics/src/Teuchos_SerialSymDenseMatrix.hpp
+++ b/packages/teuchos/numerics/src/Teuchos_SerialSymDenseMatrix.hpp
@@ -870,7 +870,7 @@ typename ScalarTraits<ScalarType>::magnitudeType SerialSymDenseMatrix<OrdinalTyp
 
   OrdinalType i, j;
 
-  MT sum = ScalarTraits<MT>::zero(), anorm = ScalarTraits<MT>::zero();
+  MT sum = ScalarTraits<MT>::zero();
 
   if (upper_) {
     for (j = 0; j < numRowCols_; j++) {
@@ -888,7 +888,7 @@ typename ScalarTraits<ScalarType>::magnitudeType SerialSymDenseMatrix<OrdinalTyp
       }
     }
   }
-  anorm = ScalarTraits<ScalarType>::magnitude(ScalarTraits<ScalarType>::squareroot(sum));
+  const MT anorm = ScalarTraits<ScalarType>::magnitude(ScalarTraits<ScalarType>::squareroot(sum));
   return(anorm);
 }
 

--- a/packages/teuchos/numerics/test/DenseMatrix/SerialSymDenseMatrix_UnitTests.cpp
+++ b/packages/teuchos/numerics/test/DenseMatrix/SerialSymDenseMatrix_UnitTests.cpp
@@ -8,9 +8,7 @@ TEST(SerialDenseMatrixBasic, DummyConstruction) {
   A(0,0) = 1.25;
   EXPECT_DOUBLE_EQ(1.25, A(0,0));
 }
-// Test cases for normFrobenius
 
-// Helper function to create a 2x2 matrix with known values
 Teuchos::SerialSymDenseMatrix<int,double> createMatrix2x2Upper() {
   Teuchos::SerialSymDenseMatrix<int,double> M(2);
   // By default, active part is lower triangular; set upper
@@ -31,6 +29,23 @@ Teuchos::SerialSymDenseMatrix<int,double> createMatrix2x2Lower() {
   return M;
 }
 
+Teuchos::SerialSymDenseMatrix<int,double> createMatrix3x3Upper() {
+  Teuchos::SerialSymDenseMatrix<int,double> M(3);
+  M.setUpper();
+  M(0,0) = 1.1; M(0,1) = 1.2; M(0,2) = 1.3;
+                M(1,1) = 2.2; M(1,2) = 2.3;
+                              M(2,2) = 3.3;
+  return M;
+}
+
+Teuchos::SerialSymDenseMatrix<int,double> createMatrix3x3Lower() {
+  Teuchos::SerialSymDenseMatrix<int,double> M(3);
+  M(0,0) = 1.1;
+  M(1,0) = 2.1; M(1,1) = 2.2;
+  M(2,0) = 3.1; M(2,1) = 3.2; M(2,2) = 3.3;
+  return M;
+}
+
 TEST(SerialSymDenseMatrixNorm, Upper2x2) {
   auto M = createMatrix2x2Upper();
   double result = M.normFrobenius();
@@ -43,5 +58,19 @@ TEST(SerialSymDenseMatrixNorm, Lower2x2) {
   auto M = createMatrix2x2Lower();
   double result = M.normFrobenius();
   double expected = 4.242640687119285; // sqrt(18)
+  EXPECT_DOUBLE_EQ(result, expected);
+}
+
+TEST(SerialSymDenseMatrixNorm, Upper3x3) {
+  auto M = createMatrix3x3Upper();
+  double result = M.normFrobenius();
+  double expected = 5.8120564346881558;
+  EXPECT_DOUBLE_EQ(result, expected);
+}
+
+TEST(SerialSymDenseMatrixNorm, Lower3x3) {
+  auto M = createMatrix3x3Lower();
+  double result = M.normFrobenius();
+  double expected = 8.0907354424675137;
   EXPECT_DOUBLE_EQ(result, expected);
 }


### PR DESCRIPTION
With mull and address sanitizer enabled, this squashes all of the mutations that mull generates in the function normFrobenius() from PR:

* #30

These commits were made manually.  But in the future, we hope an LLM AI agent will be able to make these changes automatically given feedback from Mull.